### PR TITLE
fix: hugging-cli token retrieval issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ input
 output
 models
 .vscode
+aiModels.json

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -2,13 +2,24 @@
 
 mkdir -p models
 
+# Use HF_TOKEN if set, otherwise use huggingface-cli's login.
+[ -n "$HF_TOKEN" ] && TOKEN_FLAG="--token=${HF_TOKEN}" || TOKEN_FLAG=""
+echo $TOKEN_FLAG
+
 # text-to-image, image-to-image
+echo "Downloading unrestricted models..."
 huggingface-cli download stabilityai/sd-turbo --include "*.fp16.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 huggingface-cli download stabilityai/sdxl-turbo --include "*.fp16.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 huggingface-cli download runwayml/stable-diffusion-v1-5 --include "*.fp16.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 huggingface-cli download stabilityai/stable-diffusion-xl-base-1.0 --include "*.fp16.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 huggingface-cli download prompthero/openjourney-v4 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
 huggingface-cli download ByteDance/SDXL-Lightning --include "*unet.safetensors" --exclude "*lora.safetensors*" --cache-dir models
+
 # image-to-video
 huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt --include "*.fp16.safetensors" "*.json" --cache-dir models
-huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --token=$HF_TOKEN --cache-dir models
+
+# image-to-video (token-gated)
+echo -e "\nDownloading token-gated models..." 
+huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models ${TOKEN_FLAG}
+
+echo "Models downloaded successfully!"


### PR DESCRIPTION
This pull request ensures that the user's authentication token from 'huggingface-cli' is utilized for downloading models when the `HF_TOKEN` environment variable is unset.

Not a necessity just something I use on my own machine.