### PR TITLE
fix(image-to-video): enhance error handling for width/height parameters

### DIFF
--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -59,6 +59,14 @@ async def image_to_video(
             ),
         )
 
+    if height % 8 != 0 or width % 8 != 0:
+        return JSONResponse(
+            status_code=400,
+            content=http_error(
+                f"`height` and `width` have to be divisible by 8 but are {height} and {width}."
+            ),
+        )
+
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
 


### PR DESCRIPTION
This pull request improves the error handling for the width and height parameters in the image-to-video pipeline. It ensures that a
detailed JSON error response is returned when the width and/or height parameters are not divisible by 8, as required by the
[StableVideoDiffusion](https://github.com/livepeer/ai-worker/blob/907b8c203efa475c41f4c8325f20812da9b92d34/runner/app/routes/image_to_video.py#L55) pipeline. This enhancement aids in better debugging and user experience.
