### PR TITLE
Added LOWVRAM env variable to text-to-image

### DIFF
--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -94,6 +94,8 @@ class TextToImagePipeline(Pipeline):
             self.ldm = AutoPipelineForText2Image.from_pretrained(model_id, **kwargs).to(
                 torch_device
             )
+        if os.environ.get("LOWVRAM"):
+            self.ldm.enable_sequential_cpu_offload()
 
         if os.environ.get("TORCH_COMPILE"):
             torch._inductor.config.conv_1x1_as_mm = True


### PR DESCRIPTION
Enables text-to-image sequential cpu offloading , roughly 1.2x savings of VRAM with 7.6x longer inference time.