### PR TITLE
chore: fix devcontainer GPU memory bug

### DIFF
--- a/runner/.devcontainer/devcontainer.json
+++ b/runner/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "ai-runner",
 
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// Image to use for the dev container. More info: https://containers.dev/guide/dockerfile.
 	"build": {
 		"dockerfile": "../Dockerfile"
 	},
@@ -27,8 +27,13 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		8000
-	]
+	],
 	
+	// Use 'mounts' to make a list of local folders available inside the container.
+	"mounts": [
+		"source=${localWorkspaceFolder}/models,target=/models,type=bind"
+    ]
+
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": ""
 


### PR DESCRIPTION
This pull request ensures the model's folder is correctly mounted into the dev container. By default, the local container is mounted under the `/workspace` path when using a dev container. Because of this, the fp16 variant is not used, which causes the memory on smaller cards to be insufficient.