### PR TITLE
chore(devContainer): add black format extension to config

### DIFF
--- a/runner/.devcontainer/devcontainer.json
+++ b/runner/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 		"vscode":{
 			"settings": {},
 			"extensions": [
-				"ms-python.python"
+				"ms-python.python",
+				"ms-python.black-formatter"
 			]
 		}
 	},


### PR DESCRIPTION
This pull request adds [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) vscode extension to the Dev Container.
