### PR TITLE
chore(devcontainer.json): add optional mount for models

### DIFF
--- a/runner/.devcontainer/devcontainer.json
+++ b/runner/.devcontainer/devcontainer.json
@@ -33,6 +33,7 @@
 	// Use 'mounts' to make a list of local folders available inside the container.
 	"mounts": [
 		"source=${localWorkspaceFolder}/models,target=/models,type=bind"
+		// "source=${localEnv:HOME}/.lpData/models,target=/models,type=bind"
     ]
 
 	// Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
This pull request adds an optional container mount for developers to uncomment when their models are located in the `.lpData` directory, as recommended in go-livepeer/ai-video.
