### PR TITLE
chore: add timestamp to uvicorn logs

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -52,4 +52,4 @@ COPY app/ /app/app
 COPY images/ /app/images
 COPY bench.py /app/bench.py
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--log-config", "app/cfg/uvicorn_logging_config.json", "--host", "0.0.0.0", "--port", "8000"]

--- a/runner/app/cfg/uvicorn_logging_config.json
+++ b/runner/app/cfg/uvicorn_logging_config.json
@@ -1,0 +1,46 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": "%(asctime)s %(levelprefix)s %(message)s",
+            "use_colors": null
+        },
+        "access": {
+            "()": "uvicorn.logging.AccessFormatter",
+            "fmt": "%(asctime)s %(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+        }
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr"
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout"
+        }
+    },
+    "loggers": {
+        "uvicorn": {
+            "handlers": [
+                "default"
+            ],
+            "level": "INFO",
+            "propagate": false
+        },
+        "uvicorn.error": {
+            "level": "INFO"
+        },
+        "uvicorn.access": {
+            "handlers": [
+                "access"
+            ],
+            "level": "INFO",
+            "propagate": false
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a uvicorn configuration file and uses this file during uvicorn startup to add timestamps to the uvicorn logs. The configuration is equal to the default configuration stored in `uvicorn.config.LOGGING_CONFIG` but with a timestamp prepended.
