### PR TITLE
Double quote variables to prevent globbing

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -64,7 +64,7 @@ if [ "$MODE" = "alpha" ]; then
     # Download image-to-video models (token-gated).
     printf "\nDownloading token-gated models...\n"
     check_hf_auth
-    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models ${TOKEN_FLAG}
+    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models "${TOKEN_FLAG}"
     
     printf "\nAlpha models downloaded successfully!\n"
 else
@@ -83,7 +83,7 @@ else
     # Download image-to-video models (token-gated).
     printf "\nDownloading token-gated models...\n"
     check_hf_auth
-    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models ${TOKEN_FLAG}
+    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models "${TOKEN_FLAG}"
     
     printf "\nAll models downloaded successfully!\n"
 fi


### PR DESCRIPTION
This is not an issue, just good linting - https://www.shellcheck.net/wiki/SC2086