### PR TITLE
fix(worker): fixed external container timout bug

### DIFF
--- a/worker/container.go
+++ b/worker/container.go
@@ -40,6 +40,12 @@ type RunnerContainerConfig struct {
 }
 
 func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig) (*RunnerContainer, error) {
+	// Ensure that timeout is set to a non-zero value.
+	timeout := cfg.containerTimeout
+	if timeout == 0 {
+		timeout = containerTimeout
+	}
+
 	var opts []ClientOption
 	if cfg.Endpoint.Token != "" {
 		bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(cfg.Endpoint.Token)

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -21,6 +21,7 @@ const containerModelDir = "/models"
 const containerPort = "8000/tcp"
 const pollingInterval = 500 * time.Millisecond
 const containerTimeout = 2 * time.Minute
+const externalContainerTimeout = 2 * time.Minute
 const optFlagsContainerTimeout = 5 * time.Minute
 const containerRemoveTimeout = 30 * time.Second
 const containerCreatorLabel = "creator"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -206,10 +206,11 @@ func (w *Worker) Warm(ctx context.Context, pipeline string, modelID string, endp
 	defer w.mu.Unlock()
 
 	cfg := RunnerContainerConfig{
-		Type:     External,
-		Pipeline: pipeline,
-		ModelID:  modelID,
-		Endpoint: endpoint,
+		Type:             External,
+		Pipeline:         pipeline,
+		ModelID:          modelID,
+		Endpoint:         endpoint,
+		containerTimeout: externalContainerTimeout,
 	}
 	rc, err := NewRunnerContainer(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
This pull request fixes a timeout bug that was introduced in #61 that caused external container loading to timeout before communication was established.
