### PR TITLE
feat(worker): add jpg, jpeg and .gif support in image-to-image pipeline (LIV-264)

### DIFF
--- a/worker/b64.go
+++ b/worker/b64.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"image/gif"
+	"image/jpeg"
 	"image/png"
 	"io"
 	"os"
@@ -25,6 +27,10 @@ func ReadImageB64DataUrl(url string, w io.Writer) error {
 	switch dataURL.MediaType.ContentType() {
 	case "image/png":
 		err = png.Encode(w, img)
+	case "image/jpg", "image/jpeg":
+		err = jpeg.Encode(w, img, nil)
+	case "image/gif":
+		err = gif.Encode(w, img, nil)
 		// Add cases for other image formats if necessary
 	default:
 		return fmt.Errorf("unsupported image format: %s", dataURL.MediaType.ContentType())


### PR DESCRIPTION
This change adds support for uploading jpg, jpeg and gif file formats to the image-to-image workflow.

### .jpeg
```
curl -X POST 0.0.0.0:8937/image-to-image -F image=@/home/elitedev/dog.jpeg -F prompt="a dog" -F model_id="ByteDance/SDXL-Lightning"
{"images":[{"seed":568555010,"url":"/stream/9aea34c2/6a3332f2.png"}]}
```
### .jpg
```
curl -X POST 0.0.0.0:8937/image-to-image -F image=@/home/elitedev/dog.jpg -F prompt="a dog" -F model_id="ByteDance/SDXL-Lightning"
{"images":[{"seed":3512476704,"url":"/stream/3b2f08fd/23daeba5.png"}]}
```
### .gif
```
curl -X POST 0.0.0.0:8937/image-to-image -F image=@/home/elitedev/sample.gif -F prompt="a sky at the beach" -F model_id="ByteDance/SDXL-Lightning"
{"images":[{"seed":4239492,"url":"/stream/507072fa/34179043.png"}]}
```
