### PR TITLE
Fix external containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/thanhpk/randstr v1.0.6 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/thanhpk/randstr v1.0.6 h1:psAOktJFD4vV9NEVb3qkhRSMvYh4ORRaj1+w/hn4B+o=
+github.com/thanhpk/randstr v1.0.6/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=

--- a/worker/container.go
+++ b/worker/container.go
@@ -17,6 +17,7 @@ const (
 
 type RunnerContainer struct {
 	RunnerContainerConfig
+	Name     string
 	Capacity int
 	Client   *ClientWithResponses
 }
@@ -39,7 +40,7 @@ type RunnerContainerConfig struct {
 	containerTimeout time.Duration
 }
 
-func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig) (*RunnerContainer, error) {
+func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig, name string) (*RunnerContainer, error) {
 	// Ensure that timeout is set to a non-zero value.
 	timeout := cfg.containerTimeout
 	if timeout == 0 {
@@ -70,6 +71,7 @@ func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig) (*Runner
 
 	return &RunnerContainer{
 		RunnerContainerConfig: cfg,
+		Name:                  name,
 		Capacity:              1,
 		Client:                client,
 	}, nil

--- a/worker/container.go
+++ b/worker/container.go
@@ -17,8 +17,8 @@ const (
 
 type RunnerContainer struct {
 	RunnerContainerConfig
-
-	Client *ClientWithResponses
+	Capacity int
+	Client   *ClientWithResponses
 }
 
 type RunnerEndpoint struct {
@@ -70,6 +70,7 @@ func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig) (*Runner
 
 	return &RunnerContainer{
 		RunnerContainerConfig: cfg,
+		Capacity:              1,
 		Client:                client,
 	}, nil
 }

--- a/worker/container.go
+++ b/worker/container.go
@@ -61,7 +61,7 @@ func NewRunnerContainer(ctx context.Context, cfg RunnerContainerConfig) (*Runner
 		return nil, err
 	}
 
-	cctx, cancel := context.WithTimeout(ctx, cfg.containerTimeout)
+	cctx, cancel := context.WithTimeout(context.Background(), cfg.containerTimeout)
 	if err := runnerWaitUntilReady(cctx, client, pollingInterval); err != nil {
 		cancel()
 		return nil, err

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -35,6 +35,7 @@ var containerHostPorts = map[string]string{
 	"image-to-image": "8100",
 	"image-to-video": "8200",
 	"upscale":        "8300",
+	"audio-to-text":  "8400",
 }
 
 type DockerManager struct {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -271,7 +271,10 @@ func (w *Worker) Warm(ctx context.Context, pipeline string, modelID string, endp
 	}
 
 	name := dockerContainerName(pipeline, modelID)
-	slog.Info("Starting external container", slog.String("name", name), slog.String("modelID", modelID))
+	if endpoint.URL != "" {
+		name = cfg.Endpoint.URL
+	}
+	slog.Info("Starting external container", slog.String("name", name), slog.String("pipeline", pipeline), slog.String("modelID", modelID))
 	w.externalContainers[name] = rc
 
 	return nil
@@ -311,13 +314,13 @@ func (w *Worker) HasCapacity(pipeline, modelID string) bool {
 func (w *Worker) borrowContainer(ctx context.Context, pipeline, modelID string) (*RunnerContainer, error) {
 	w.mu.Lock()
 
-	name := dockerContainerName(pipeline, modelID)
-	rc, ok := w.externalContainers[name]
-	if ok {
-		w.mu.Unlock()
-		// We allow concurrent in-flight requests for external containers and assume that it knows
-		// how to handle them
-		return rc, nil
+	for _, rc := range w.externalContainers {
+		if rc.Pipeline == pipeline && rc.ModelID == modelID {
+			w.mu.Unlock()
+			// We allow concurrent in-flight requests for external containers and assume that it knows
+			// how to handle them
+			return rc, nil
+		}
 	}
 
 	w.mu.Unlock()


### PR DESCRIPTION
The changes in this PR allow connection to external containers and selection of the external containers by an orchestrator more efficiently.  Limit of 1 request per container at a time initially.  A 1 request queue would be a nice addition but I think is not needed right now.

Note: the go-livepeer/ai-video for selection updates relies on this update to ai-worker.