### PR TITLE
feat(worker): add HasCapability method

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -239,6 +239,22 @@ func (w *Worker) Stop(ctx context.Context) error {
 	return nil
 }
 
+// HasCapacity returns true if the worker has capacity for the given pipeline and model ID.
+func (w *Worker) HasCapacity(pipeline, modelID string) bool {
+	managedCapacity := w.manager.HasCapacity(context.Background(), pipeline, modelID)
+	if managedCapacity {
+		return true
+	}
+
+	// Check if we have capacity for external containers.
+	name := dockerContainerName(pipeline, modelID)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, ok := w.externalContainers[name]
+
+	return ok
+}
+
 func (w *Worker) borrowContainer(ctx context.Context, pipeline, modelID string) (*RunnerContainer, error) {
 	w.mu.Lock()
 


### PR DESCRIPTION
This commit adds a HasCapability method to the worker that can be used to check if the worker has enough capacity to take a request. This method will be used to check if an O has enough capability to support a request in https://github.com/livepeer/go-livepeer/tree/ai-video. This will prevent the Gateway from paying for requests send the the O when it has no capacity.