### PR TITLE
fix(pipelines): fix image truncation bug when seed is set

### DIFF
--- a/runner/app/routes/image_to_image.py
+++ b/runner/app/routes/image_to_image.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 responses = {400: {"model": HTTPError}, 500: {"model": HTTPError}}
 
 
-# TODO: Make model_id optional once Go codegen tool supports OAPI 3.1
-# https://github.com/deepmap/oapi-codegen/issues/373
+# TODO: Make model_id and other properties optional once Go codegen tool supports
+# OAPI 3.1 https://github.com/deepmap/oapi-codegen/issues/373
 @router.post("/image-to-image", response_model=ImageResponse, responses=responses)
 @router.post(
     "/image-to-image/",
@@ -61,11 +61,11 @@ async def image_to_image(
         )
 
     if seed is None:
-        init_seed = random.randint(0, 2**32 - 1)
-        if num_images_per_prompt > 1:
-            seed = [i for i in range(init_seed, init_seed + num_images_per_prompt)]
-        else:
-            seed = init_seed
+        seed = random.randint(0, 2**32 - 1)
+    if num_images_per_prompt > 1:
+        seed = [
+            i for i in range(seed, seed + num_images_per_prompt)
+        ]
 
     img = Image.open(image.file).convert("RGB")
     # If a list of seeds/generators is passed, diffusers wants a list of images

--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 responses = {400: {"model": HTTPError}, 500: {"model": HTTPError}}
 
 
-# TODO: Make model_id optional once Go codegen tool supports OAPI 3.1
-# https://github.com/deepmap/oapi-codegen/issues/373
+# TODO: Make model_id and other properties optional once Go codegen tool supports
+# OAPI 3.1 https://github.com/deepmap/oapi-codegen/issues/373
 @router.post("/image-to-video", response_model=VideoResponse, responses=responses)
 @router.post(
     "/image-to-video/",

--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 class TextToImageParams(BaseModel):
-    # TODO: Make model_id optional once Go codegen tool supports OAPI 3.1
-    # https://github.com/deepmap/oapi-codegen/issues/373
+    # TODO: Make model_id and other properties optional once Go codegen tool supports
+    # OAPI 3.1 https://github.com/deepmap/oapi-codegen/issues/373
     model_id: str = ""
     prompt: str
     height: int = None
@@ -56,13 +56,11 @@ async def text_to_image(
         )
 
     if params.seed is None:
-        init_seed = random.randint(0, 2**32 - 1)
-        if params.num_images_per_prompt > 1:
-            params.seed = [
-                i for i in range(init_seed, init_seed + params.num_images_per_prompt)
-            ]
-        else:
-            params.seed = init_seed
+        params.seed = random.randint(0, 2**32 - 1)
+    if params.num_images_per_prompt > 1:
+        params.seed = [
+            i for i in range(params.seed, params.seed + params.num_images_per_prompt)
+        ]
 
     try:
         images = pipeline(**params.model_dump())


### PR DESCRIPTION
This pull request ensure that all images are returned when a seed is set in the old code only the fist image of the badge was returned. Fixes LIV-309e.
