### PR TITLE
chore(runner): update OpenAPI spec server URI

### DIFF
--- a/runner/openapi.json
+++ b/runner/openapi.json
@@ -7,8 +7,8 @@
     },
     "servers": [
         {
-            "url": "http://gateway-endpoint.ai/",
-            "description": "Example Gateway"
+            "url": "https://dream-gateway.livepeer.cloud",
+            "description": "Livepeer Cloud Community Gateway"
         }
     ],
     "paths": {


### PR DESCRIPTION
This pull request updates the OpenAPI server to the https://livepeer.cloud community gateway.
