### PR TITLE
fix(I2V): Prevent `nil` pointer runtime error

### DIFF
--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -92,7 +92,10 @@ async def image_to_video(
     output_frames = []
     for frames in batch_frames:
         output_frames.append(
-            [{"url": image_to_data_url(frame), "seed": seed} for frame in frames]
+            [
+                {"url": image_to_data_url(frame), "seed": seed, "nsfw": False}
+                for frame in frames
+            ]
         )
 
     return {"frames": output_frames}


### PR DESCRIPTION
This pull request ensures the response format of the I2V pipeline is correct, preventing a `nil` pointer runtime error on the Gateway side.
