### PR TITLE
fix(worker): throw error for empty container response

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -194,6 +194,11 @@ func (w *Worker) ImageToVideo(ctx context.Context, req ImageToVideoMultipartRequ
 		return nil, errors.New("image-to-video container returned 500")
 	}
 
+	if resp.JSON200 == nil {
+		slog.Error("image-to-video container returned no content")
+		return nil, errors.New("image-to-video container returned no content")
+	}
+
 	return resp.JSON200, nil
 }
 


### PR DESCRIPTION
This pull request ensures that an error is returned to the gateway when the runner container returns a successful but empty response.
