### PR TITLE
fix: fix huggingface token not found error

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -64,7 +64,7 @@ if [ "$MODE" = "alpha" ]; then
     # Download image-to-video models (token-gated).
     printf "\nDownloading token-gated models...\n"
     check_hf_auth
-    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models "${TOKEN_FLAG:+$TOKEN_FLAG}"
+    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models ${TOKEN_FLAG:+"$TOKEN_FLAG"}
 
     printf "\nAlpha models downloaded successfully!\n"
 else
@@ -85,7 +85,7 @@ else
     # Download image-to-video models (token-gated).
     printf "\nDownloading token-gated models...\n"
     check_hf_auth
-    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models "${TOKEN_FLAG:+$TOKEN_FLAG}"
+    huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt-1-1 --include "*.fp16.safetensors" "*.json" --cache-dir models ${TOKEN_FLAG:+"$TOKEN_FLAG"}
 
     printf "\nAll models downloaded successfully!\n"
 fi


### PR DESCRIPTION
This pull request ensures that a more descriptive error is thrown when the huggingface token is not set. Fixes https://linear.app/livepeer-ai-spe/issue/LIV-392/fix-huggingface-login-token-not-found-error.
