### PR TITLE
feat(runner): disable DEEPCACHE for lightning/turbo models

### DIFF
--- a/runner/app/pipelines/util.py
+++ b/runner/app/pipelines/util.py
@@ -8,6 +8,7 @@ from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from transformers import CLIPFeatureExtractor
 from typing import Optional
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,8 @@ def is_lightning_model(model_id: str) -> bool:
     Returns:
         True if the model is a Lightning model, False otherwise.
     """
-    return "-lightning" in model_id.lower()
+    return re.search(r"[-_]lightning", model_id, re.IGNORECASE) is not None
+
 
 def is_turbo_model(model_id: str) -> bool:
     """Checks if the model is a Turbo model.
@@ -71,7 +73,8 @@ def is_turbo_model(model_id: str) -> bool:
     Returns:
         True if the model is a Turbo model, False otherwise.
     """
-    return "-turbo" in model_id.lower()
+    return re.search(r"[-_]turbo", model_id, re.IGNORECASE) is not None
+
 
 class SafetyChecker:
     """Checks images for unsafe or inappropriate content using a pretrained model.

--- a/runner/app/pipelines/util.py
+++ b/runner/app/pipelines/util.py
@@ -51,6 +51,28 @@ def validate_torch_device(device_name: str) -> bool:
         return False
 
 
+def is_lightning_model(model_id: str) -> bool:
+    """Checks if the model is a Lightning model.
+
+    Args:
+        model_id: Model ID.
+
+    Returns:
+        True if the model is a Lightning model, False otherwise.
+    """
+    return "-lightning" in model_id.lower()
+
+def is_turbo_model(model_id: str) -> bool:
+    """Checks if the model is a Turbo model.
+
+    Args:
+        model_id: Model ID.
+
+    Returns:
+        True if the model is a Turbo model, False otherwise.
+    """
+    return "-turbo" in model_id.lower()
+
 class SafetyChecker:
     """Checks images for unsafe or inappropriate content using a pretrained model.
 


### PR DESCRIPTION
This commit ensures that people can not use the [deepcache](https://github.com/horseee/DeepCache) optimization with lightning and turbo models. As explained in https://github.com/livepeer/ai-worker/issues/82#issuecomment-2141983903 this optimization does not offer any speedup for these models while it does reduce image quality.
