### PR TITLE
fix(runner): update img2img to do sequential processing of batch request

### DIFF
--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -67,7 +67,7 @@ async def text_to_image(
     params.num_images_per_prompt = 1
     for seed in seeds:
         try:
-            params.seed = [seed]
+            params.seed = seed
             imgs, nsfw_check = pipeline(**params.model_dump())
             images.extend(imgs)
             has_nsfw_concept.extend(nsfw_check)


### PR DESCRIPTION
This PR updates the image-to-image router in runner to process the batch requests sequentially.  Similar to text-to-image, this will stabilize GPU memory usage and allow for some GPUs to run multiple instances of lighter weight models.

