### PR TITLE
fix(api): fix incorrect I2I OpenAPI gateway spec

### DIFF
--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -82,7 +82,7 @@ async def image_to_video(
             motion_bucket_id=motion_bucket_id,
             noise_aug_strength=noise_aug_strength,
             safety_check=safety_check,
-            seed=seed
+            seed=seed,
         )
     except Exception as e:
         logger.error(f"ImageToVideoPipeline error: {e}")
@@ -95,7 +95,11 @@ async def image_to_video(
     for frames in batch_frames:
         output_frames.append(
             [
-                {"url": image_to_data_url(frame), "seed": seed, "nsfw": has_nsfw_concept[0]}
+                {
+                    "url": image_to_data_url(frame),
+                    "seed": seed,
+                    "nsfw": has_nsfw_concept[0],
+                }
                 for frame in frames
             ]
         )


### PR DESCRIPTION
This pull request ensures that the right format is set in the OpenAPI spec forwhen the I2I response is coming from the gateway. This is a little bit hacky since we don't yet generate the OpenAPI spec where it is implemented (i.e. in go-livepeer).
