### PR TITLE
fix: pin numpy version to prevent conflits

### DIFF
--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -13,3 +13,4 @@ peft==0.11.1
 deepcache==0.1.1
 safetensors==0.4.3
 scipy==1.13.0
+numpy==1.26.4


### PR DESCRIPTION
This pull request ensures that numpy<2.0.0 is used to prevent conflicts with Pytorch 2.1.1. We can upgrade these packages in the future (see https://github.com/pytorch/pytorch/issues/107302).
