### PR TITLE
enable multiple prompts for T2I

### DIFF
--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -222,8 +222,24 @@ class TextToImagePipeline(Pipeline):
                 # Default to 8step
                 kwargs["num_inference_steps"] = 8
 
-        output = self.ldm(prompt, **kwargs)
-
+        prompts = prompt.split("|", 3)
+        prompt = prompts[0]
+        if len(prompts) > 1:
+            kwargs["prompt_2"] = prompts[1]
+        if len(prompts) > 2:
+            kwargs["prompt_3"] = prompts[2]
+        
+        if "negative_prompt" in kwargs:
+            negative_prompts = prompt.split("|", 3)
+            kwargs["negative_prompt"] = negative_prompts[0]
+            if len(negative_prompts) > 1:
+                kwargs["negative_prompt_2"] = negative_prompts[1]
+            if len(negative_prompts) > 2:
+                kwargs["negative_prompt_3"] = negative_prompts[2]
+        
+        
+        output = self.ldm(prompt=prompt, **kwargs)
+        
         if safety_check:
             _, has_nsfw_concept = self._safety_checker.check_nsfw_images(output.images)
         else:

--- a/runner/app/pipelines/utils/__init__.py
+++ b/runner/app/pipelines/utils/__init__.py
@@ -7,5 +7,6 @@ from app.pipelines.utils.utils import (
     get_torch_device,
     is_lightning_model,
     is_turbo_model,
+    split_prompt,
     validate_torch_device,
 )

--- a/runner/app/pipelines/utils/utils.py
+++ b/runner/app/pipelines/utils/utils.py
@@ -79,6 +79,39 @@ def is_turbo_model(model_id: str) -> bool:
     return re.search(r"[-_]turbo", model_id, re.IGNORECASE) is not None
 
 
+def split_prompt(
+    input_prompt: str,
+    separator: str = "|",
+    key_prefix: str = "prompt",
+    max_splits: int = -1,
+) -> dict[str, str]:
+    """Splits an input prompt into prompts, including the main prompt, with customizable
+    key naming.
+
+    Args:
+        input_prompt (str): The input prompt string to be split.
+        separator (str): The character used to split the input prompt. Defaults to '|'.
+        key_prefix (str): Prefix for keys in the returned dictionary for all prompts,
+            including the main prompt. Defaults to 'prompt'.
+        max_splits (int): Maximum number of splits to perform. Defaults to -1 (no limit).
+
+    Returns:
+        Dict[str, str]: A dictionary of all prompts, including the main prompt.
+    """
+    prompts = input_prompt.split(separator, max_splits - 1)
+    start_index = 1 if max_splits < 0 else max(1, len(prompts) - max_splits)
+
+    prompt_dict = {f"{key_prefix}": prompts[0].strip()}
+    prompt_dict.update(
+        {
+            f"{key_prefix}_{i+1}": prompt.strip()
+            for i, prompt in enumerate(prompts[1:], start=start_index)
+        }
+    )
+
+    return prompt_dict
+
+
 class SafetyChecker:
     """Checks images for unsafe or inappropriate content using a pretrained model.
 


### PR DESCRIPTION
This PR enables requests to use multiple prompts supported by SDXL and SD3 with no API updates needed.  Diffusers uses the same prompt in all text_encoders if the prompts are not split.  Multiple prompts is supported by SDXL and SD3 models and can benefit from specializing the prompts to the different text_ecnoders if tuned properly.

The prompts are split by including a `|` at the point where want the prompts split.  

For SDXL see diffusers pipeline documentation here:https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl
Specifically the `prompt_2` input to the `__call__`: https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_xl#diffusers.StableDiffusionXLPipeline.__call__

For SD3 see diffusers pipeline documentation here: https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_3
Specifically the `prompt_2` and `prompt_3` inputs to the `__call__`: https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_diffusion/stable_diffusion_3#diffusers.StableDiffusion3Pipeline.__call__