### PR TITLE
ci: add PR OpenAPI/bindings check action

### DIFF
--- a/.github/workflows/validate-openapi-on-pr.yaml
+++ b/.github/workflows/validate-openapi-on-pr.yaml
@@ -1,10 +1,10 @@
-name: Check OpenAPI spec & Golang bindings update
+name: Check OpenAPI spec and Golang bindings
 
 on:
   pull_request:
 
 jobs:
-  check-openapi-spec:
+  check-openapi-and-bindings:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,27 +22,23 @@ jobs:
           pip install -r runner/requirements.txt
 
       - name: Generate AI OpenAPI specification
+        working-directory: runner
         run: |
-          cd runner
           python gen_openapi.py
-          cd $GITHUB_WORKSPACE
 
-      - name: Check OpenAPI change
+      - name: Check for OpenAPI spec changes
         run: |
-          git diff --exit-code
-          if [ $? -ne 0 ]; then
-            echo "OpenAPI spec has changed. Please run 'python gen_openapi.py' and commit the changes."
+          if ! git diff --exit-code; then
+            echo "::error:: OpenAPI spec has changed. Please run 'python gen_openapi.py' in the 'runner' directory and commit the changes."
             exit 1
           fi
 
       - name: Generate Go bindings
-        run: |
-          make
+        run: make
 
-      - name: Check Go bindings change
+      - name: Check for Go bindings changes
         run: |
-          git diff --exit-code
-          if [ $? -ne 0 ]; then
-            echo "Go bindings have changed. Please run 'make' and commit the changes."
+          if ! git diff --exit-code; then
+            echo "::error::Go bindings have changed. Please run 'make' at the root of the repository and commit the changes."
             exit 1
           fi

--- a/.github/workflows/validate-openapi-on-pr.yaml
+++ b/.github/workflows/validate-openapi-on-pr.yaml
@@ -1,0 +1,48 @@
+name: Check OpenAPI spec & Golang bindings update
+
+on:
+  pull_request:
+
+jobs:
+  check-openapi-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r runner/requirements.txt
+
+      - name: Generate AI OpenAPI specification
+        run: |
+          cd runner
+          python gen_openapi.py
+          cd $GITHUB_WORKSPACE
+
+      - name: Check OpenAPI change
+        run: |
+          git diff --exit-code
+          if [ $? -ne 0 ]; then
+            echo "OpenAPI spec has changed. Please run 'python gen_openapi.py' and commit the changes."
+            exit 1
+          fi
+
+      - name: Generate Go bindings
+        run: |
+          make
+
+      - name: Check Go bindings change
+        run: |
+          git diff --exit-code
+          if [ $? -ne 0 ]; then
+            echo "Go bindings have changed. Please run 'make' and commit the changes."
+            exit 1
+          fi


### PR DESCRIPTION
This pull request adds a simple action that notifies developers when they forgot to update the OpenAPI spec or golang bindings.
