### PR TITLE
enable specifying schedulers for text-to-image

### DIFF
--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -2,6 +2,7 @@ import logging
 import os
 from enum import Enum
 from typing import List, Optional, Tuple
+from copy import deepcopy
 
 import PIL
 import torch
@@ -13,6 +14,8 @@ from app.pipelines.utils import (
     is_lightning_model,
     is_turbo_model,
     split_prompt,
+    load_scheduler_presets,
+    create_scheduler
 )
 from diffusers import (
     AutoPipelineForText2Image,
@@ -116,6 +119,12 @@ class TextToImagePipeline(Pipeline):
             self.ldm = AutoPipelineForText2Image.from_pretrained(model_id, **kwargs).to(
                 torch_device
             )
+
+        #save the default scheduler
+        self.default_scheduler = deepcopy(self.ldm.scheduler)
+        #load the scheduler presets
+        self.scheduler_presets = load_scheduler_presets(self.__class__.__name__)
+        logger.info(f"loaded scheduler presets for {self.__class__.__name__}")
 
         if os.environ.get("TORCH_COMPILE"):
             torch._inductor.config.conv_1x1_as_mm = True
@@ -232,6 +241,17 @@ class TextToImagePipeline(Pipeline):
             max_splits=3,
         )
         kwargs.update(neg_prompts)
+
+        set_scheduler = kwargs.pop("scheduler", None)
+        logger.info(f"setting pipeline scheduler to: {set_scheduler}")
+        if set_scheduler:
+            new_scheduler, args, error = create_scheduler(set_scheduler, self.scheduler_presets)
+            if new_scheduler:
+                self.ldm.scheduler = new_scheduler.from_config(self.default_scheduler.config, **args)
+            else:
+                raise ValueError(f"scheduler could not be created: {error}")
+        else:
+            self.ldm.scheduler = self.default_scheduler
 
         output = self.ldm(prompt=prompt, **kwargs)
 

--- a/runner/app/pipelines/utils/__init__.py
+++ b/runner/app/pipelines/utils/__init__.py
@@ -10,3 +10,8 @@ from app.pipelines.utils.utils import (
     split_prompt,
     validate_torch_device,
 )
+
+from app.pipelines.utils.schedulers import (
+    load_scheduler_presets,
+    create_scheduler
+)

--- a/runner/app/pipelines/utils/schedulers.py
+++ b/runner/app/pipelines/utils/schedulers.py
@@ -1,0 +1,60 @@
+import importlib, json, logging
+from typing import Tuple, get_type_hints
+
+logger = logging.getLogger(__name__)
+
+text_to_image_presets = {
+    "DPM++ 2M": { "name": "DPMSolverMultistepScheduler", "args": {} },
+    "DPM++ 2M Karras": { "name": "DPMSolverMultistepScheduler", "args": { "use_karras_sigmas": True } },
+    "DPM++ 2M SDE": { "name": "DPMSolverMultistepScheduler", "args": { "algorithm_type": "sde-dpmsolver++" } },
+    "DPM++ 2M SDE Karras": { "name": "DPMSolverMultistepScheduler", "args": { "use_karras_sigmas": True, "algorithm_type": "sde-dpmsolver++" } },
+    "DPM++ 2S a": { "name": "DPMSolverSinglestepScheduler", "args": {} },
+    "DPM++ 2S a Karras": { "name": "DPMSolverSinglestepScheduler", "args": { "use_karras_sigmas": True } },
+    "DPM++ SDE": { "name": "DPMSolverSinglestepScheduler", "args": {} },
+    "DPM++ SDE Karras": { "name": "DPMSolverSinglestepScheduler", "args": { "use_karras_sigmas": True } },
+    "DPM2": { "name": "KDPM2DiscreteScheduler", "args": {} },
+    "DPM2 Karras": { "name": "KDPM2DiscreteScheduler", "args": { "use_karras_sigmas": True } },
+    "DPM2 a": { "name": "KDPM2AncestralDiscreteScheduler", "args": {} },
+    "DPM2 a Karras": { "name": "KDPM2AncestralDiscreteScheduler", "args": { "use_karras_sigmas": True } },
+    "Euler": { "name": "EulerDiscreteScheduler", "args": {} },
+    "Euler a": { "name": "EulerAncestralDiscreteScheduler", "args": {} },
+    "Euler flow match": { "name": "FlowMatchEulerDiscreteScheduler", "args": {} },
+    "Huen": { "name": "HeunDiscreteScheduler", "args": {} },
+    "LMS": { "name": "LMSDiscreteScheduler", "args": {} },
+    "LMS Karras": { "name": "LMSDiscreteScheduler", "args": { "use_karras_sigmas": True } }
+}
+
+
+def load_scheduler_presets(pipeline: str) -> any:
+    if pipeline is "TextToImagePipeline":
+        return text_to_image_presets
+    else:
+        return {}
+
+def create_scheduler(scheduler: str, presets: dict) -> Tuple[object, dict, str]:
+    """
+    creates scheduler from provided settings (name/args).  Presets available for convenience setting main schedulers
+    """
+    set_sch = json.loads(scheduler)
+    set_sch_name = set_sch.get("name", None)
+    if set_sch_name in presets:
+        set_sch["name"] = presets[set_sch_name]["name"]
+        set_sch["args"] = presets[set_sch_name]["args"] | set_sch["args"]
+    
+    try:
+        sch_cls = getattr(importlib.import_module("diffusers"), set_sch["name"])
+        #convert params to correct type.  The from_config method passes the **kwargs provided directly
+        #to the __init__ method of the scheduler (diffusers/src/diffusers/configuration_utils.py)
+        type_hints = get_type_hints(sch_cls.__init__)
+        for arg in set_sch["args"]:
+            try:
+                set_sch["args"][arg] = type_hints[arg](set_sch["args"][arg])
+            except:
+                return None, None, f"params not in correct format: {arg}={set_sch['args'][arg]}"
+            
+        return sch_cls, set_sch["args"], ""
+
+    except BaseException as e:
+        return None, None, f"scheduler not available: {e}"
+    
+    

--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -28,6 +28,7 @@ class TextToImageParams(BaseModel):
     seed: int = None
     num_inference_steps: int = 50  # NOTE: Hardcoded due to varying pipeline values.
     num_images_per_prompt: int = 1
+    scheduler: str = ""
 
 
 RESPONSES = {

--- a/runner/openapi.json
+++ b/runner/openapi.json
@@ -742,6 +742,11 @@
                         "type": "integer",
                         "title": "Num Images Per Prompt",
                         "default": 1
+                    },
+                    "scheduler": {
+                        "type": "string",
+                        "title": "Scheduler",
+                        "default": ""
                     }
                 },
                 "type": "object",

--- a/worker/runner.gen.go
+++ b/worker/runner.gen.go
@@ -119,6 +119,7 @@ type TextToImageParams struct {
 	NumInferenceSteps  *int     `json:"num_inference_steps,omitempty"`
 	Prompt             string   `json:"prompt"`
 	SafetyCheck        *bool    `json:"safety_check,omitempty"`
+	Scheduler          *string  `json:"scheduler,omitempty"`
 	Seed               *int     `json:"seed,omitempty"`
 	Width              *int     `json:"width,omitempty"`
 }
@@ -1481,32 +1482,32 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZ227bOBN+FYL/f+nEhzabhe+SbLcNtoegdrsXRWAw0thmK5FaHtJ6A7/7gkNZomQp",
-	"cpDGC2R9Zcsaznxz+IZD+o5GMs2kAGE0Hd9RHS0hZfj17OrylVJSue+ZkhkowwHfpHrhPgw3CdAxfacX",
-	"tEfNKnMP2iguFnS97lEFf1muIKbjL7jkulcsKXQX6+TNV4gMXffouYxXM2ZjLmdGzgz8MLWnTGqzDQpl",
-	"3Je5VCkzdExvuGBqRQOrKLIFtUdTGUMy47FbHsOc2cStD1a+cwLkMu7006MIPN3Nm7Yw8JQtwIn6L7XH",
-	"5kAsLI+ZiGCmI+YgBC6dHp+UyF7ncmSCcgUEYdMbUA4CWrk/pJco0hBSj/AeLMMQC6oh3YgekageFbBg",
-	"ht/CLFMyzUyrjve5HLnyck2qbOpzoGcZqCaFw0CfTQk6qMkVqC2tXBhYePdQrZiDAoyZgUxXlQ4GNbUb",
-	"YTJB4SalJbjNyna/NJuDWc2iJUTfKpaNslCanqAYuUCxQs2NlAkwgXoA4tDixD03gdNGgViYZcXY4PjX",
-	"wNZGYqscatTLNl75sq1zcAcqdbLwlscg64/NLJzXUvdLCef3lkQtgS+W1So6OQ3WvfHvm5Y+hqmP4lQq",
-	"DZdidmOjb2DqSoaj01CLkyTnKFnRFhJAcg0zZhezlsIYjAICOGFyZhekvUa6OTU6eTil9k6T7zyuhWI4",
-	"GL0sLf2J77dX1ijSwYz28m5jhs2wsRefzVz416qzK/enJ8+qnT6sITbmriHRb6bTq5ZBMAbDeOK+/V/B",
-	"nI7p//rlONnPZ8l+MezVAebLA2ClrRYgn1nCY+Y6SSckbiDVXdjq+tYllt+8pgIIU4qt0IcQbV1BE25g",
-	"iVlebIqgilcbZmy1KumHP2i4/6FA0+BZbgylgQb7yK2PoDMpNLSwU+8csXcQcxbGyY82TXHaaj06zHUV",
-	"VgNub2kLr9Dz7yEZ3rvnR3VXq5JQ7pNKOud8izLaa0REgWceeINHU/hh2hMRLa34tnsiUDxMxIVfX09E",
-	"j7pzRuigg9HpofFCOajAu4oTLU5OJWb3iinmHXmqI0o5M+0wJf3HTw8nz+3wUExFDxyDcqdqNV2t2YbC",
-	"7tx7EhlV2MvE6sOcjr/cbcXqbgvidUDktzJCMw1Url+9gNYtg5P/oRRFzGTqfu2ivvPDm8olg0jtsN99",
-	"dnNje5ubK5bW9psHbjz19rY5V3nFHRtRbj50qYK3wSHfabcc2a2tOjspaMPSLHQ1wD0t3ndAN6GgMxY4",
-	"4TFugUc6RVZxs5q4OHrkbnA5B6ZAFXd+yEH/U6FkaUxG104HF3PpKa0jxTMszjE9E4RlWcJ9tRIjibKC",
-	"nF2SjGeQcOGTsSlqfgsZgHLvP1oh0NAtKO11DY6HxwMXLZmBYBmnY/oCf+rRjJklwu7jzdmRkUeb0G/O",
-	"Gy4tCOIy3tzzTWWeDxdB0MbNvLjLSmFA4KrUJoZnTJm+O5gcxcyw8g60qxx3u9hbV3PoOiH+4IsNvRoN",
-	"BjVcQVD7X7ULz66gKnsz2q5mbGKjCLSe24SUYj368idCKEf4BvvnLCYffT683eF+7H4SzJqlVPxviNHw",
-	"8MV+DOfOklfCcLMiUynJW6YWPuqj0U8FsXWW2YZTipDivHOyr+RfCgNKsIRMQN2CIuWhcNOicK8Mm9OX",
-	"6/V1j2qbpkytNswmU0mQ225pf4mHH5wqoaEX+LMRfULOhaevXSm3Dp3KIaI3OBa6DlfcmTS3OBxV8onl",
-	"iXvcDhene+5y1ZPjoc21t7lDh3loh/H/RE2lP3PVSIk3op2kxHlyX6Rsv7PdMymrU/SBlAdSPgEpPbWQ",
-	"lG7G3mGjDE7291LycTN39e7gsB0emPdMmOeKu7Yb5v8XtVPuUy7wtDtg499XB+YdmPdMmLdh0dqvcmo0",
-	"LqpaKq7VLhJpY3Ih09QKblbkNTPwna1o/vcWXubpcb8fK2Dp0cK/PU7y5ceRW07X1+t/AgAA///2pVcb",
-	"EigAAA==",
+	"H4sIAAAAAAAC/+xZS3PbNhD+Kxi0R9l6JK47utlumniahydS0kPGo4HJlYSEBFg8nKge/fcOFhQJUmQo",
+	"j2N16uokUdzHt7v4FgvojkYyzaQAYTQd31EdLSFl+PXs6vKFUlK575mSGSjDAd+keuE+DDcJ0DF9oxe0",
+	"R80qcw/aKC4WdL3uUQV/Wa4gpuNPqHLdK1QK24WevPkMkaHrHj2X8WrGbMzlzMiZgW+m9pRJbbZBoYz7",
+	"MpcqZYaO6Q0XTK1o4BVFtqD2aCpjSGY8duoxzJlNnH6g+cYJkMu4M06PIoh0t2ja0sBTtgAn6r/UHpsT",
+	"sbA8ZiKCmY6YgxCEdHp8UiJ7mcuRCcoVEIRNb0A5COjl+ym9RJGGlHqE38EyDLGgGdKN6AGF6lEBC2b4",
+	"LcwyJdPMtNp4m8uRKy/XZMqmvgZ6loFqMjgM7NmUYICaXIHassqFgYUPD82KOSjAnBnIdNXoYFAzuxEm",
+	"ExRuMlqC22i2x6XZHMxqFi0h+lLxbJSF0vUExcgFihVmbqRMgAm0AxCHHifuuQmcNgrEwiwrzgbHvwa+",
+	"NhJby6FGvWwTlV+2dQ7uQKVOFt7yGGT9sZmF81rpfinh/N5SqCXwxbK6ik5OA71X/n2T6kOY+iBOpdJw",
+	"KWY3NvoCpm5kODoNrThJco6SFWshASTXMGN2MWtZGINRQAAnTM7sgrSvkW5OjU7uT6m90+Qrj2upGA5G",
+	"z0tPf+L7bc0aRTqY0b6825hhM2zsxWczF/611dlV+9OTJ9VO79cQG2vXUOhX0+lVyyAYg2E8cd9+VjCn",
+	"Y/pTvxwn+/ks2S+GvTrAXD0AVvpqAfKRJTxmrpN0QuIGUt2FrW5vXWL5zVsqgDCl2ApjCNHWDTThBpaY",
+	"5cVmEVTxasOMra5K+u4PGu5/KNA0eJYbQ+mgwT9y6z3oTAoNLezUO2fsDcSchXnyo01TnrZajw5rXYXV",
+	"gNt72sIr9PxrSIa37vlB3dWqJJT7oJLOOd+ijPYWEVEQmQfeENEUvpn2QkRLK77sXggUDwtx4fXrhehR",
+	"d84IA3QwOiM0XigHFURXCaIlyKnE6l4xxXwgj3VEKWemHaak//np4eS/cniIlhDbBFRrjieFRBOMew9V",
+	"95yi8pzUKFFd8g286Ny6EhlVyM/E6t2cjj/dbcV4twXxOugDr2WEbho6Qf3mBrRumbv8D6UoYiZT92tX",
+	"53BxeFe5ZJCpHbbLj27sbO+Sc8XS2nZ1z32r3h03xzJvuGMfy92HIVXwNgTkG/VWILt1ZecnBW1YmoWh",
+	"BrinxfsO6CYUdM6CIDzGLfBIp8gqblaOc3ni3dxzDkx5hmKCkcL+p8LI0piMrp0NLubSk1lHime4OMf0",
+	"TBCWZQn3q5UYSZQV5OySZDyDhAtfjM2i5reQASj3/r0VAh3dgtLe1uB4eDxw2ZIZCJZxOqbP8KcezZhZ",
+	"Iuw+XrwdGXm0Sf3muOLKgiAu48014VTm9XAZBG3cyIybtBQGBGqlNjE8Y8r03bnmKGaGlVeoXctxt3vB",
+	"dbWGrpHiD36xYVSjwaCGK0hq/7N26dkVVGVrR9/Vik1sFIHWc5uQUqxHn/9ACOUJoMH/OYvJe18P73e4",
+	"H78fBLNmKRX/G2J0PHy2H8d5sOSFMNysyFRK8pqphc/6aPRDQWwdhbbhlCKkOC6d7Kv4l8KAEiwhE1C3",
+	"oEh5pty0KNwrw+b06Xp93aPapilTqw2zyVQS5LZT7S/x7IRDKTT0An+0oo/IufDwtivl1mFQOUSMBqdK",
+	"1+GKK5fmFoejSj6xPHKP2+Hedc9drnrwPLS59jZ36DD37TD+j6yp9Ee2GinxQrWTlDhP7ouU7Ve+eyZl",
+	"dYo+kPJAykcgpacWktLN2DtslMHJ/ruUfNjMXb07OGyHB+Y9Eea5xV3bDfO/m9op9yEXeNwdsPHfrwPz",
+	"Dsx7IszbsGjttZwZjUpVT8W12kUibUwuZJpawc2KvGQGvrIVzf8dw8s8Pe73YwUsPVr4t8dJrn4cOXW6",
+	"vl7/EwAA//8n47ePUSgAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
This PR adds ability to set schedulers using a json string in the request for t2i pipeline. `name` of the scheduler can be a preset or a class name for the scheduler from `diffusers`.

There are presets to make setting the main schedulers easier from https://huggingface.co/docs/diffusers/en/api/schedulers/overview.

Scheduler is created by mapping the preset name to the `diffusers` scheduler class using `importlib` so the schedulers are not imported until needed.
If a scheduler fails to be added the pipeline raises an error.  If no scheduler is specified the default scheduler is applied.

performance testing:
loading no scheduler (reassigns default scheduler)
`2024-07-28 01:12:00,677 - app.pipelines.text_to_image - INFO - setting pipeline scheduler to: `
`2024-07-28 01:12:00,677 - app.pipelines.text_to_image - INFO - loading scheduler took 0.0002524852752685547s`

loading DPM++ 2M scheduler from preset on RealVisXL_V4.0 model
`2024-07-28 01:13:44,851 - app.pipelines.text_to_image - INFO - setting pipeline scheduler to: {"name":"DPM++ 2M","args":{}}`
`2024-07-28 01:13:44,858 - app.pipelines.text_to_image - INFO - loading scheduler took 0.00660252571105957s`

loading DPM2 scheduler from preset on RealVisXL_V4.0 model
`2024-07-28 01:10:39,576 - app.pipelines.text_to_image - INFO - setting pipeline scheduler to: {"name":"DPM2","args":{}}`
`2024-07-28 01:10:39,817 - app.pipelines.text_to_image - INFO - loading scheduler took 0.24109697341918945s`

loading Euler flow match for SD3, setting shift arg.
`2024-07-28 01:42:36,853 - app.pipelines.text_to_image - INFO - setting pipeline scheduler to: {"name":"Euler flow match","args":{"shift":"3"}}`
`2024-07-28 01:42:36,856 - app.pipelines.text_to_image - INFO - loading scheduler took 0.002814054489135742s`


format of json string in http request:
`{
  "name": "Euler",
  "args": {}
}`