### PR TITLE
ci: add TS/JS SDK OpenAPI spec update trigger

### DIFF
--- a/.github/workflows/trigger-upstream-openapi-sync.yaml
+++ b/.github/workflows/trigger-upstream-openapi-sync.yaml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - "runner/openapi.json"
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -12,6 +14,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set trigger source
+        id: set-trigger-source
+        run: echo "triggered_by=${{ github.event_name == 'workflow_dispatch' && 'manual' || 'version' }}" >> $GITHUB_ENV
 
       - name: Trigger experimental SDKs update
         uses: peter-evans/repository-dispatch@v3
@@ -22,20 +28,29 @@ jobs:
           client-payload: '{"sha": "${{ github.sha }}"}'
         
       - name: Trigger released JS/TS SDK update
-        # if: startsWith(github.ref, 'refs/tags/') # Only run on release.
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.SDKS_TRIGGER_PAT }}
-          repository: livepeer/ai-sdk-js
+          repository: rickstaa/ai-sdk-js
           event-type: update-ai-openapi
-          client-payload: '{"sha": "${{ github.sha }}"}'
+          client-payload: >-
+            {
+              "sha": "${{ github.sha }}",
+              "version": "${{ github.ref_name }}",
+              "triggered_by": "${{ env.triggered_by }}"
+            }
 
   trigger-docs-openapi-sync:
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/') # Only run on release.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set trigger source
+        id: set-trigger-source
+        run: echo "triggered_by=${{ github.event_name == 'workflow_dispatch' && 'manual' || 'version' }}" >> $GITHUB_ENV
 
       - name: Trigger docs AI OpenAPI spec update
         uses: peter-evans/repository-dispatch@v3
@@ -43,4 +58,9 @@ jobs:
           token: ${{ secrets.DOCS_TRIGGER_PAT }}
           repository: rickstaa/docs
           event-type: update-ai-openapi
-          client-payload: '{"sha": "${{ github.sha }}"}'
+          client-payload: >-
+            {
+              "sha": "${{ github.sha }}",
+              "version": "${{ github.ref_name }}",
+              "triggered_by": "${{ env.triggered_by }}"
+            }


### PR DESCRIPTION
This action addes a trigger to update the OpenAPI spec in https://github.com/livepeer/ai-sdk-js. Furhter it improves the OpenAPI spec upstream sync action to forward more information.