### PR TITLE
ci: update OpenAPI spec trigger repos

### DIFF
--- a/.github/workflows/trigger-upstream-openapi-sync.yaml
+++ b/.github/workflows/trigger-upstream-openapi-sync.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.SDKS_TRIGGER_PAT }}
-          repository: rickstaa/ai-sdk-js
+          repository: livepeer/ai-sdk-js
           event-type: update-ai-openapi
           client-payload: >-
             {
@@ -56,7 +56,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.DOCS_TRIGGER_PAT }}
-          repository: rickstaa/docs
+          repository: livepeer/docs
           event-type: update-ai-openapi
           client-payload: >-
             {


### PR DESCRIPTION
This pull request ensures the right upstream repos are triggered in the trigger upstream OpenAPI sync action.
