### PR TITLE
ci: fix OpenAPI spec check action

### DIFF
--- a/.github/workflows/validate-openapi-on-pr.yaml
+++ b/.github/workflows/validate-openapi-on-pr.yaml
@@ -1,6 +1,9 @@
 name: Check OpenAPI spec and Golang bindings
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -9,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This pull request fixes the OpenAPI spec check action. This action can be used to ensure the OpenAPI spec and go bindings are up to date.
