### PR TITLE
chore: update make go-bindings generation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ codegen:
 	go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.2.0 \
 		-package worker \
 		-generate types,client,chi-server,spec \
-		runner/openapi.json \
+		runner/openapi.yaml \
 		| awk '!/WARNING/' > worker/runner.gen.go


### PR DESCRIPTION
This pull request ensures that the make file uses the right OpenAPI spec to generate the go bindings.
