### PR TITLE
add video support to segment-anything-2 pipeline

### DIFF
--- a/runner/app/pipelines/segment_anything_2.py
+++ b/runner/app/pipelines/segment_anything_2.py
@@ -1,11 +1,17 @@
 import logging
+import shutil
+import tempfile
 from typing import List, Optional, Tuple
 
-import PIL
+from PIL import Image
+from fastapi import UploadFile
+import torch
 from app.pipelines.base import Pipeline
 from app.pipelines.utils import get_torch_device
 from app.routes.util import InferenceError
 from sam2.sam2_image_predictor import SAM2ImagePredictor
+from sam2.sam2_video_predictor import SAM2VideoPredictor
+import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -15,22 +21,73 @@ class SegmentAnything2Pipeline(Pipeline):
         self.model_id = model_id
 
         torch_device = get_torch_device()
+        if torch_device.type == "cuda":
+            torch.autocast("cuda", dtype=torch.bfloat16).__enter__()
+            # turn on tfloat32 for Ampere GPUs (https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices)
+            if torch.cuda.get_device_properties(0).major >= 8:
+                torch.backends.cuda.matmul.allow_tf32 = True
+                torch.backends.cudnn.allow_tf32 = True
+        elif torch_device.type == "mps":
+            print(
+                "\nSupport for MPS devices is preliminary. SAM 2 is trained with CUDA and might "
+                "give numerically different outputs and sometimes degraded performance on MPS. "
+                "See e.g. https://github.com/pytorch/pytorch/issues/84936 for a discussion."
+            )
 
         self.tm = SAM2ImagePredictor.from_pretrained(
             model_id=model_id,
             device=torch_device,
         )
+        
+        self.tm_vid = SAM2VideoPredictor.from_pretrained(
+            model_id=model_id,
+            device=torch_device,
+        )
 
     def __call__(
-        self, image: PIL.Image, **kwargs
-    ) -> Tuple[List[PIL.Image], List[Optional[bool]]]:
+        self, media_file: UploadFile, media_type: str, **kwargs
+    ) -> Tuple[List[UploadFile], str, List[Optional[bool]]]:
+        if media_type == "image":
+            try:
+                image = Image.open(media_file.file)
+                self.tm.set_image(image)
+                prediction = self.tm.predict(**kwargs)
+            except Exception as e:
+                raise InferenceError(original_exception=e)
+        elif media_type == "video":
+            try:
+                temp_dir = tempfile.mkdtemp()
+                # TODO: Fix the file type dependency, try passing to ffmpeg without saving to file
+                video_path = f"{temp_dir}/input.mp4"
+                with open(video_path, "wb") as video_file:
+                    video_file.write(media_file.file.read())
+                
+                # Run ffmpeg command to extract frames from video
+                frame_dir = tempfile.mkdtemp()
+                output_pattern = f"{frame_dir}/%05d.jpg"
+                ffmpeg_command = f"ffmpeg -i {video_path} -q:v 2 -start_number 0 {output_pattern}"
+                subprocess.run(ffmpeg_command, shell=True, check=True)
+                shutil.rmtree(temp_dir) 
+                
+                inference_state = self.tm_vid.init_state(video_path=frame_dir)
+                shutil.rmtree(frame_dir)
 
-        self.tm.set_image(image)
-
-        try:
-            prediction = self.tm.predict(**kwargs)
-        except Exception as e:
-            raise InferenceError(original_exception=e)
+                _, out_obj_ids, out_mask_logits = self.tm_vid.add_new_points_or_box(
+                    inference_state,
+                    frame_idx=5,
+                    obj_id=1,
+                    points=kwargs.get('point_coords', None),
+                    labels=kwargs.get('point_labels', None),
+                    )
+                video_segments = {}  # video_segments contains the per-frame segmentation results
+                for out_frame_idx, out_obj_ids, out_mask_logits in self.tm_vid.propagate_in_video(inference_state):
+                    video_segments[out_frame_idx] = {
+                        out_obj_id: (out_mask_logits[i] > 0.0).cpu().numpy()
+                        for i, out_obj_id in enumerate(out_obj_ids)
+                    }
+                return video_segments
+            except Exception as e:
+                raise InferenceError(original_exception=e)
 
         return prediction
 

--- a/runner/app/routes/segment_anything_2.py
+++ b/runner/app/routes/segment_anything_2.py
@@ -37,7 +37,7 @@ RESPONSES = {
     include_in_schema=False,
 )
 async def SegmentAnything2(
-    image: Annotated[UploadFile, File()],
+    media_file: Annotated[UploadFile, File()],
     model_id: Annotated[str, Form()] = "",
     point_coords: Annotated[str, Form()] = None,
     point_labels: Annotated[str, Form()] = None,
@@ -78,18 +78,53 @@ async def SegmentAnything2(
             content=http_error(str(e)),
         )
 
+    supported_video_types = ["video/mp4"]
+    supported_image_types = ["image/jpeg", "image/png", "image/jpg"]
+
     try:
-        image = Image.open(image.file)
-        masks, scores, low_res_mask_logits = pipeline(
-            image,
-            point_coords=point_coords,
-            point_labels=point_labels,
-            box=box,
-            mask_input=mask_input,
-            multimask_output=multimask_output,
-            return_logits=return_logits,
-            normalize_coords=normalize_coords,
-        )
+        if media_file.content_type in supported_image_types:
+            masks, scores, low_res_mask_logits = pipeline(
+                media_file,
+                media_type="image",
+                point_coords=point_coords,
+                point_labels=point_labels,
+                box=box,
+                mask_input=mask_input,
+                multimask_output=multimask_output,
+                return_logits=return_logits,
+                normalize_coords=normalize_coords,
+            )
+
+            # Return masks sorted by descending score as JSON.
+            sorted_ind = np.argsort(scores)[::-1]
+            return {
+                "masks":  str(masks[sorted_ind].tolist()),
+                "scores":  str(scores[sorted_ind].tolist()),
+                "logits":  str(low_res_mask_logits[sorted_ind].tolist()),
+            }
+        elif media_file.content_type in supported_video_types:
+            out_masks = pipeline(
+                media_file,
+                media_type="video",
+                point_coords=point_coords,
+                point_labels=point_labels,
+                box=box,
+                mask_input=mask_input,
+                multimask_output=None,
+                return_logits=None,
+                normalize_coords=None,
+            )
+            
+            # Return masks sorted by descending score as JSON.
+            # TODO fix return output to something useful
+            return {
+                "masks":  str(out_masks),
+                "scores":  str(""),
+                "logits":  str(""),
+            }
+        else:
+            raise InferenceError(f"Unsupported media type: {media_file.content_type}")
+
     except Exception as e:
         logger.error(f"Segment Anything 2 error: {e}")
         logger.exception(e)
@@ -104,10 +139,3 @@ async def SegmentAnything2(
             content=http_error("Segment Anything 2 error"),
         )
 
-    # Return masks sorted by descending score as JSON.
-    sorted_ind = np.argsort(scores)[::-1]
-    return {
-        "masks":  str(masks[sorted_ind].tolist()),
-        "scores":  str(scores[sorted_ind].tolist()),
-        "logits":  str(low_res_mask_logits[sorted_ind].tolist()),
-    }


### PR DESCRIPTION
This change updates the request field `image` to `media_file` and loads the appropriate segment-anything-2 inference model based on the content type of the file. It uses ffmpeg to process the video to image frames and loads them in with inference values from the request. Some adjustments still need to be made to the request/response parameters

