### PR TITLE
Text to video pipeline

### DIFF
--- a/runner/app/main.py
+++ b/runner/app/main.py
@@ -46,6 +46,10 @@ def load_pipeline(pipeline: str, model_id: str) -> any:
             from app.pipelines.audio_to_text import AudioToTextPipeline
 
             return AudioToTextPipeline(model_id)
+        case "text-to-video":
+            from app.pipelines.text_to_video import TextToVideoPipeline
+
+            return TextToVideoPipeline(model_id)
         case "frame-interpolation":
             raise NotImplementedError("frame-interpolation pipeline not implemented")
         case "upscale":
@@ -76,6 +80,10 @@ def load_route(pipeline: str) -> any:
             from app.routes import audio_to_text
 
             return audio_to_text.router
+        case "text-to-video":
+            from app.routes import text_to_video
+
+            return text_to_video.router
         case "frame-interpolation":
             raise NotImplementedError("frame-interpolation pipeline not implemented")
         case "upscale":

--- a/runner/app/pipelines/text_to_video.py
+++ b/runner/app/pipelines/text_to_video.py
@@ -1,0 +1,78 @@
+from app.pipelines.base import Pipeline
+from app.pipelines.util import get_torch_device, get_model_dir
+
+from diffusers import DiffusionPipeline
+from huggingface_hub import file_download
+import torch
+import PIL
+from typing import List
+import logging
+import os
+
+from PIL import ImageFile
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+logger = logging.getLogger(__name__)
+
+
+class TextToVideoPipeline(Pipeline):
+    def __init__(self, model_id: str):
+        kwargs = {"cache_dir": get_model_dir()}
+
+        torch_device = get_torch_device()
+        folder_name = file_download.repo_folder_name(
+            repo_id=model_id, repo_type="model"
+        )
+        folder_path = os.path.join(get_model_dir(), folder_name)
+        has_fp16_variant = any(
+            ".fp16.safetensors" in fname
+            for _, _, files in os.walk(folder_path)
+            for fname in files
+        )
+        if torch_device != "cpu" and has_fp16_variant:
+            logger.info("TextToVideoPipeline loading fp16 variant for %s", model_id)
+
+            kwargs["torch_dtype"] = torch.float16
+            kwargs["variant"] = "fp16"
+
+        self.model_id = model_id
+        self.ldm = DiffusionPipeline.from_pretrained(model_id, **kwargs)
+        self.ldm.to(get_torch_device())
+
+        if os.environ.get("SFAST"):
+            logger.info(
+                "TextToVideoPipeline will be dynamicallly compiled with stable-fast for %s",
+                model_id,
+            )
+            from app.pipelines.sfast import compile_model
+
+            self.ldm = compile_model(self.ldm)
+
+    def __call__(self, prompt: str, **kwargs) -> List[List[PIL.Image]]:
+        # ali-vilab/text-to-video-ms-1.7b has a limited parameter set
+        if (
+            self.model_id == "ali-vilab/text-to-video-ms-1.7b"
+        ):
+            if "fps" in kwargs:
+                del kwargs["fps"]
+            if "motion_bucket_id" in kwargs:
+                del kwargs["motion_bucket_id"]
+            if "noise_aug_strength" in kwargs:
+                del kwargs["noise_aug_strength"]
+
+        seed = kwargs.pop("seed", None)
+        if seed is not None:
+            if isinstance(seed, int):
+                kwargs["generator"] = torch.Generator(get_torch_device()).manual_seed(
+                    seed
+                )
+            elif isinstance(seed, list):
+                kwargs["generator"] = [
+                    torch.Generator(get_torch_device()).manual_seed(s) for s in seed
+                ]
+
+        return self.ldm(prompt, **kwargs).frames
+
+    def __str__(self) -> str:
+        return f"TextToVideoPipeline model_id={self.model_id}"

--- a/runner/app/routes/text_to_video.py
+++ b/runner/app/routes/text_to_video.py
@@ -1,0 +1,182 @@
+from fastapi import APIRouter, Depends, Form, status, Depends, APIRouter, Form
+from pydantic import BaseModel, Field
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from app.pipelines.base import Pipeline
+from app.dependencies import get_pipeline
+from app.routes.util import image_to_data_url, VideoResponse, HTTPError, http_error
+from typing import Annotated
+import logging
+import random
+import os
+
+router = APIRouter()
+
+logger = logging.getLogger(__name__)
+
+class TextToVideoParams(BaseModel):
+    # TODO: Make model_id and other None properties optional once Go codegen tool
+    # supports OAPI 3.1 https://github.com/deepmap/oapi-codegen/issues/373
+    model_id: Annotated[
+        str,
+        Field(
+            default="", description="Hugging Face model ID used for video generation."
+        ),
+    ]
+    prompt: Annotated[
+        str,
+        Field(
+            description=(
+                "Text prompt(s) to guide video generation. Separate multiple prompts "
+                "with '|' if supported by the model."
+            )
+        ),
+    ]
+    height: Annotated[
+        int,
+        Field(default=576, description="The height in pixels of the generated video."),
+    ]
+    width: Annotated[
+        int,
+        Field(default=1024, description="The width in pixels of the generated video."),
+    ]
+    fps: Annotated[
+        int, Form(description="The frames per second of the generated video.")
+    ] = 8,
+    motion_bucket_id: Annotated[
+        int,
+        Form(
+            description=(
+                "Used for conditioning the amount of motion for the generation. The "
+                "higher the number the more motion will be in the video."
+            )
+        ),
+    ] = 127,
+    noise_aug_strength: Annotated[
+        float,
+        Form(
+            description=(
+                "Amount of noise added to the conditioning image. Higher values reduce "
+                "resemblance to the conditioning image and increase motion."
+            )
+        ),
+    ] = 0.02,
+    guidance_scale: Annotated[
+        float,
+        Field(
+            default=7.5,
+            description=(
+                "Encourages model to generate videos closely linked to the text prompt "
+                "(higher values may reduce image quality)."
+            ),
+        ),
+    ]
+    negative_prompt: Annotated[
+        str,
+        Field(
+            default="",
+            description=(
+                "Text prompt(s) to guide what to exclude from video generation. "
+                "Ignored if guidance_scale < 1."
+            ),
+        ),
+    ]
+    safety_check: Annotated[
+        bool,
+        Field(
+            default=True,
+            description=(
+                "Perform a safety check to estimate if generated videos could be "
+                "offensive or harmful."
+            ),
+        ),
+    ]
+    seed: Annotated[
+        int, Field(default=None, description="Seed for random number generation.")
+    ]
+    num_inference_steps: Annotated[
+        int,
+        Field(
+            default=50,
+            description=(
+                "Number of denoising steps. More steps usually lead to higher quality "
+                "images but slower inference. Modulated by strength."
+            ),
+        ),
+    ]
+    num_images_per_prompt: Annotated[
+        int,
+        Field(default=1, description="Number of videos to generate per prompt."),
+    ]
+
+RESPONSES = {
+    status.HTTP_400_BAD_REQUEST: {"model": HTTPError},
+    status.HTTP_401_UNAUTHORIZED: {"model": HTTPError},
+    status.HTTP_413_REQUEST_ENTITY_TOO_LARGE: {"model": HTTPError},
+    status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": HTTPError},
+}
+
+@router.post(
+    "/text-to-video",
+    response_model=VideoResponse,
+    responses=RESPONSES,
+    description="Generate videos from text prompts.",
+)
+@router.post(
+    "/text-to-video/",
+    response_model=VideoResponse,
+    responses=RESPONSES,
+    include_in_schema=False,
+)
+async def text_to_video(
+    params: TextToVideoParams,
+    pipeline: Pipeline = Depends(get_pipeline),
+    token: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+):
+    auth_token = os.environ.get("AUTH_TOKEN")
+    if auth_token:
+        if not token or token.credentials != auth_token:
+            return JSONResponse(
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+                content=http_error("Invalid bearer token"),
+            )
+
+    if params.model_id != "" and params.model_id != pipeline.model_id:
+        return JSONResponse(
+            status_code=400,
+            content=http_error(
+                f"pipeline configured with {pipeline.model_id} but called with {params.model_id}"
+            ),
+        )
+
+    if params.height % 8 != 0 or params.width % 8 != 0:
+        return JSONResponse(
+            status_code=400,
+            content=http_error(
+                f"`height` and `width` have to be divisible by 8 but are {params.height} and {params.width}."
+            ),
+        )
+
+    if params.seed is None:
+        params.seed = random.randint(0, 2**32 - 1)
+
+    try:
+        params.seed = seed
+        kwargs = {k: v for k, v in params.model_dump().items() if k != "model_id"}
+        batch_frames = pipeline(**kwargs)
+    except Exception as e:
+        logger.error(f"TextToVideoPipeline error: {e}")
+        logger.exception(e)
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=http_error("TextToVideoPipeline error"),
+        )
+
+    output_frames = []
+    for frames in batch_frames:
+        output_frames.append(
+            [{"url": image_to_data_url(frame), "seed": params.seed} for frame in frames]
+        )
+
+    return {"frames": output_frames}

--- a/runner/app/routes/text_to_video.py
+++ b/runner/app/routes/text_to_video.py
@@ -41,26 +41,23 @@ class TextToVideoParams(BaseModel):
         Field(default=1024, description="The width in pixels of the generated video."),
     ]
     fps: Annotated[
-        int, Form(description="The frames per second of the generated video.")
-    ] = 8,
+        int,
+        Field(default=8, description="The frames per second of the generated video."),
+    ]
     motion_bucket_id: Annotated[
         int,
-        Form(
-            description=(
-                "Used for conditioning the amount of motion for the generation. The "
-                "higher the number the more motion will be in the video."
-            )
-        ),
-    ] = 127,
+        Field(default=127, description=(
+            "Used for conditioning the amount of motion for the generation. The "
+            "higher the number the more motion will be in the video."
+        )),
+    ]
     noise_aug_strength: Annotated[
         float,
-        Form(
-            description=(
-                "Amount of noise added to the conditioning image. Higher values reduce "
-                "resemblance to the conditioning image and increase motion."
-            )
-        ),
-    ] = 0.02,
+        Field(default=0.02, description=(
+            "Amount of noise added to the conditioning image. Higher values reduce "
+            "resemblance to the conditioning image and increase motion."
+        )),
+    ]
     guidance_scale: Annotated[
         float,
         Field(
@@ -92,7 +89,7 @@ class TextToVideoParams(BaseModel):
         ),
     ]
     seed: Annotated[
-        int, Field(default=None, description="Seed for random number generation.")
+        int, Field(default=None, description="Seed for random number generation."),
     ]
     num_inference_steps: Annotated[
         int,
@@ -103,10 +100,6 @@ class TextToVideoParams(BaseModel):
                 "images but slower inference. Modulated by strength."
             ),
         ),
-    ]
-    num_images_per_prompt: Annotated[
-        int,
-        Field(default=1, description="Number of videos to generate per prompt."),
     ]
 
 RESPONSES = {
@@ -162,7 +155,6 @@ async def text_to_video(
         params.seed = random.randint(0, 2**32 - 1)
 
     try:
-        params.seed = seed
         kwargs = {k: v for k, v in params.model_dump().items() if k != "model_id"}
         batch_frames = pipeline(**kwargs)
     except Exception as e:

--- a/runner/app/routes/util.py
+++ b/runner/app/routes/util.py
@@ -7,6 +7,7 @@ from fastapi import UploadFile
 from PIL import Image
 from pydantic import BaseModel, Field
 
+import numpy as np
 
 class Media(BaseModel):
     """A media object containing information about the generated media."""
@@ -93,6 +94,8 @@ def image_to_data_url(img: Image, format: str = "png") -> str:
     Returns:
         The data URL for the image.
     """
+    if isinstance(img, np.ndarray):
+        img = Image.fromarray((img * 255).astype(np.uint8))
     return "data:image/png;base64," + image_to_base64(img, format=format)
 
 

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -60,6 +60,10 @@ function download_all_models() {
 
     # Download image-to-video models.
     huggingface-cli download stabilityai/stable-video-diffusion-img2vid-xt --include "*.fp16.safetensors" "*.json" --cache-dir models
+
+    # Download text-to-video models.
+    huggingface-cli download THUDM/CogVideoX-2b "*.json" --cache-dir models
+    huggingface-cli download THUDM/CogVideoX-5b "*.json" --cache-dir models
 }
 
 # Enable HF transfer acceleration.

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -235,6 +235,56 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /text-to-video:
+    post:
+      summary: Text To Video
+      description: Generate videos from text prompts.
+      operationId: text_to_video
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TextToVideoParams'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '413':
+          description: Request Entity Too Large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
 components:
   schemas:
     APIError:
@@ -562,6 +612,86 @@ components:
       - prompt
       - model_id
       title: TextToImageParams
+    TextToVideoParams:
+      properties:
+        model_id:
+          type: string
+          title: Model Id
+          description: Hugging Face model ID used for video generation.
+          default: ''
+        prompt:
+          type: string
+          title: Prompt
+          description: Text prompt(s) to guide video generation. Separate multiple
+            prompts with '|' if supported by the model.
+        height:
+          type: integer
+          title: Height
+          description: The height in pixels of the generated video.
+          default: 576
+        width:
+          type: integer
+          title: Width
+          description: The width in pixels of the generated video.
+          default: 1024
+        fps:
+          type: integer
+          title: Fps
+          description: The frames per second of the generated video.
+          default:
+          - 8
+        motion_bucket_id:
+          type: integer
+          title: Motion Bucket Id
+          description: Used for conditioning the amount of motion for the generation.
+            The higher the number the more motion will be in the video.
+          default:
+          - 127
+        noise_aug_strength:
+          type: number
+          title: Noise Aug Strength
+          description: Amount of noise added to the conditioning image. Higher values
+            reduce resemblance to the conditioning image and increase motion.
+          default:
+          - 0.02
+        guidance_scale:
+          type: number
+          title: Guidance Scale
+          description: Encourages model to generate videos closely linked to the text
+            prompt (higher values may reduce image quality).
+          default: 7.5
+        negative_prompt:
+          type: string
+          title: Negative Prompt
+          description: Text prompt(s) to guide what to exclude from video generation.
+            Ignored if guidance_scale < 1.
+          default: ''
+        safety_check:
+          type: boolean
+          title: Safety Check
+          description: Perform a safety check to estimate if generated videos could
+            be offensive or harmful.
+          default: true
+        seed:
+          type: integer
+          title: Seed
+          description: Seed for random number generation.
+        num_inference_steps:
+          type: integer
+          title: Num Inference Steps
+          description: Number of denoising steps. More steps usually lead to higher
+            quality images but slower inference. Modulated by strength.
+          default: 50
+        num_images_per_prompt:
+          type: integer
+          title: Num Images Per Prompt
+          description: Number of images to generate per prompt.
+          default: 1
+      type: object
+      required:
+      - prompt
+      - model_id
+      title: TextToVideoParams
     ValidationError:
       properties:
         loc:

--- a/runner/gen_openapi.py
+++ b/runner/gen_openapi.py
@@ -11,6 +11,7 @@ from app.routes import (
     image_to_video,
     text_to_image,
     upscale,
+    text_to_video,
 )
 from fastapi.openapi.utils import get_openapi
 import subprocess
@@ -121,6 +122,7 @@ def write_openapi(fname: str, entrypoint: str = "runner", version: str = "0.0.0"
     app.include_router(image_to_video.router)
     app.include_router(upscale.router)
     app.include_router(audio_to_text.router)
+    app.include_router(text_to_video.router)
 
     use_route_names_as_operation_ids(app)
 

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -246,6 +246,56 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /text-to-video:
+    post:
+      summary: Text To Video
+      description: Generate videos from text prompts.
+      operationId: text_to_video
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TextToVideoParams'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '413':
+          description: Request Entity Too Large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
 components:
   schemas:
     APIError:
@@ -576,6 +626,85 @@ components:
       required:
       - prompt
       title: TextToImageParams
+    TextToVideoParams:
+      properties:
+        model_id:
+          type: string
+          title: Model Id
+          description: Hugging Face model ID used for video generation.
+          default: ''
+        prompt:
+          type: string
+          title: Prompt
+          description: Text prompt(s) to guide video generation. Separate multiple
+            prompts with '|' if supported by the model.
+        height:
+          type: integer
+          title: Height
+          description: The height in pixels of the generated video.
+          default: 576
+        width:
+          type: integer
+          title: Width
+          description: The width in pixels of the generated video.
+          default: 1024
+        fps:
+          type: integer
+          title: Fps
+          description: The frames per second of the generated video.
+          default:
+          - 8
+        motion_bucket_id:
+          type: integer
+          title: Motion Bucket Id
+          description: Used for conditioning the amount of motion for the generation.
+            The higher the number the more motion will be in the video.
+          default:
+          - 127
+        noise_aug_strength:
+          type: number
+          title: Noise Aug Strength
+          description: Amount of noise added to the conditioning image. Higher values
+            reduce resemblance to the conditioning image and increase motion.
+          default:
+          - 0.02
+        guidance_scale:
+          type: number
+          title: Guidance Scale
+          description: Encourages model to generate videos closely linked to the text
+            prompt (higher values may reduce image quality).
+          default: 7.5
+        negative_prompt:
+          type: string
+          title: Negative Prompt
+          description: Text prompt(s) to guide what to exclude from video generation.
+            Ignored if guidance_scale < 1.
+          default: ''
+        safety_check:
+          type: boolean
+          title: Safety Check
+          description: Perform a safety check to estimate if generated videos could
+            be offensive or harmful.
+          default: true
+        seed:
+          type: integer
+          title: Seed
+          description: Seed for random number generation.
+        num_inference_steps:
+          type: integer
+          title: Num Inference Steps
+          description: Number of denoising steps. More steps usually lead to higher
+            quality images but slower inference. Modulated by strength.
+          default: 50
+        num_images_per_prompt:
+          type: integer
+          title: Num Images Per Prompt
+          description: Number of images to generate per prompt.
+          default: 1
+      type: object
+      required:
+      - prompt
+      title: TextToVideoParams
     ValidationError:
       properties:
         loc:

--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -1,6 +1,6 @@
-diffusers==0.30.0
-accelerate==0.30.1
-transformers==4.41.1
+diffusers==0.30.1
+accelerate==0.33.0
+transformers==4.44.0
 fastapi==0.111.0
 pydantic==2.7.2
 Pillow==10.3.0

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -36,6 +36,7 @@ var containerHostPorts = map[string]string{
 	"image-to-video": "8200",
 	"upscale":        "8300",
 	"audio-to-text":  "8400",
+	"text-to-video":  "8500",
 }
 
 type DockerManager struct {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -250,6 +250,48 @@ func (w *Worker) Upscale(ctx context.Context, req UpscaleMultipartRequestBody) (
 	return resp.JSON200, nil
 }
 
+func (w *Worker) TextToVideo(ctx context.Context, req TextToVideoJSONRequestBody) (*VideoResponse, error) {
+	c, err := w.borrowContainer(ctx, "text-to-video", *req.ModelId)
+	if err != nil {
+		return nil, err
+	}
+	defer w.returnContainer(c)
+
+	resp, err := c.Client.TextToVideoWithResponse(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.JSON422 != nil {
+		val, err := json.Marshal(resp.JSON422)
+		if err != nil {
+			return nil, err
+		}
+		slog.Error("text-to-video container returned 422", slog.String("err", string(val)))
+		return nil, errors.New("text-to-video container returned 422")
+	}
+
+	if resp.JSON400 != nil {
+		val, err := json.Marshal(resp.JSON400)
+		if err != nil {
+			return nil, err
+		}
+		slog.Error("text-to-video container returned 400", slog.String("err", string(val)))
+		return nil, errors.New("text-to-video container returned 400")
+	}
+
+	if resp.JSON500 != nil {
+		val, err := json.Marshal(resp.JSON500)
+		if err != nil {
+			return nil, err
+		}
+		slog.Error("text-to-video container returned 500", slog.String("err", string(val)))
+		return nil, errors.New("text-to-video container returned 500")
+	}
+
+	return resp.JSON200, nil
+}
+
 func (w *Worker) AudioToText(ctx context.Context, req AudioToTextMultipartRequestBody) (*TextResponse, error) {
 	c, err := w.borrowContainer(ctx, "audio-to-text", *req.ModelId)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for a `text-to-video` pipeline using the [THUDM/CogVideoX-2b](https://huggingface.co/THUDM/CogVideoX-2b) and [THUDM/CogVideoX-5b](https://huggingface.co/THUDM/CogVideoX-5b) models

This PR is a WIP:
- `num_frames` parameter is currently hardcoded to their recommended value of `49`
- The `torch_dtype` parameters are currently hardcoded to their recommended values. We probably want to modify the `dl_checkpoints.sh` some more and detect which precision we want to use.
- Generic code cleanup & code commenting
- Included the VAE speedups (`enable_slicing`, `enable_tiling`), we might want to play around with these