### PR TITLE
feat: add ability to allocate multiple GPUs to runner container

### DIFF
--- a/worker/docker.go
+++ b/worker/docker.go
@@ -166,7 +166,8 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 	}
 
 	// NOTE: We currently allow only one container per GPU for each pipeline.
-	containerHostPort := containerHostPorts[pipeline][:3] + gpu
+	gpuDevices := strings.Split(gpu, "|")
+	containerHostPort := containerHostPorts[pipeline][:3] + gpuDevices[0]
 	containerName := dockerContainerName(pipeline, modelID, containerHostPort)
 	containerImage := m.defaultImage
 	if pipelineSpecificImage, ok := pipelineToImage[pipeline]; ok {
@@ -198,12 +199,12 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		},
 	}
 
+	devReq := container.DeviceRequest{Driver: "nvidia", DeviceIDs: gpuDevices, Capabilities: [][]string{{"gpu"}}}
 	gpuOpts := opts.GpuOpts{}
-	gpuOpts.Set("device=" + gpu)
 
 	hostConfig := &container.HostConfig{
 		Resources: container.Resources{
-			DeviceRequests: gpuOpts.Value(),
+			DeviceRequests: append(gpuOpts.Value(), devReq),
 		},
 		Mounts: []mount.Mount{
 			{


### PR DESCRIPTION
This commit allows adding multiple GPUs to a runner container.  The `-nvidia` flag in go-livepeer startup can specify multiple gpus by adding a `|` between the gpu IDs.

`-nvidia 0|1|2,2` will allocate GPUs 0,1 and 2 to first block in aiModels.json.  GPU 2 will be allocated to second block in aiModels.json.

An extra note, you can control what GPUs are allocated to aiModels.json blocks by the order of the GPUs in the nvidia flag. `-nvidia 1,0` will allocate GPU 1 to first aiModels.json block and GPU 0 to second aiModels.json block.