### PR TITLE
chore(ci): add 'base' tag and segment-anything-2 docker image build

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -61,6 +61,7 @@ jobs:
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=base,enable={{is_default_branch}}
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
@@ -72,6 +73,18 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           file: "Dockerfile"
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeerci/build:cache
+          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+      
+      - name: Build and push segment-anything-2 docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: "{{defaultContext}}:runner"
+          platforms: linux/amd64
+          push: true
+          tags: livepeer/ai-runner:segment-anything-2
+          file: "docker/Dockerfile.segment_anything_2"
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=livepeerci/build:cache
           cache-to: type=registry,ref=livepeerci/build:cache,mode=max

--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -65,6 +65,15 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
+      - name: Cleanup hosted runner
+        run: |
+          sudo apt purge -yqq dotnet-* mono-* llvm-* libllvm* powershell* openjdk-* \
+          temurin-* mongodb-* firefox mysql-* \
+          hhvm google-chrome-stable \
+          libgl1-mesa-dri microsoft-edge-stable azure-cli || true
+          sudo apt autoremove -y
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+          
       - name: Build and push runner docker image
         uses: docker/build-push-action@v5
         with:

--- a/runner/docker/Dockerfile.segment_anything_2
+++ b/runner/docker/Dockerfile.segment_anything_2
@@ -1,4 +1,5 @@
-FROM livepeer/ai-runner:base
+ARG BASE_IMAGE=livepeer/ai-runner:base
+FROM ${BASE_IMAGE}
 
 RUN pip install --no-cache-dir torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1 xformers==0.0.27 git+https://github.com/facebookresearch/segment-anything-2.git@main#egg=sam-2
 


### PR DESCRIPTION
Updates github docker action to add `livepeer/ai-runner:base` image tag and builds the segment-anything-2 image.

The segment-anything-2 dockerfile was also updated to move the base image to a ARG line that can be overriden using `--build-arg` to set the base image.