### PR TITLE
ci(docker): add ai-runner base Docker tag

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -1,4 +1,4 @@
-name: Build Docker image for ai-runner
+name: Build ai-runner base Docker image
 
 on:
   pull_request:
@@ -61,6 +61,7 @@ jobs:
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=base,enable={{is_default_branch}}
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 


### PR DESCRIPTION
This pull request ensures that the main Docker container is also tagged as the base container so that it can be used as the base for the pipeline specific containers.
