### PR TITLE
ci(docker): ensure docker ci dispatch works

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   docker:
     name: Docker image generation
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
This pull request ensures that the workflow dispatch triggers the docker job.
