### PR TITLE
ci(docker): enable pipeline docker workflow dispatch

### DIFF
--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - "runner/**"
       - "!runner/.devcontainer/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -21,7 +22,7 @@ concurrency:
 jobs:
   sam2-docker:
     name: SAM2 Docker image generation
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
This pull request ensures that maintainers can manually run the pipeline docker ci.
