### PR TITLE
docker build for salad and salad_app.py to setup environment

### DIFF
--- a/runner/docker/Dockerfile.salad
+++ b/runner/docker/Dockerfile.salad
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=livepeer/ai-runner:base
+FROM ${BASE_IMAGE}
+
+RUN pip install --no-cache-dir huggingface_hub
+
+COPY ./dl_checkpoints.sh /app
+COPY ./salad_app.py /app
+
+CMD ["python", "-u", "/app/salad_app.py"]

--- a/runner/salad_app.py
+++ b/runner/salad_app.py
@@ -1,0 +1,56 @@
+import logging
+import os
+import argparse
+from huggingface_hub import snapshot_download
+import re
+import uvicorn
+import json
+
+logger = logging.getLogger(__name__)
+
+MODELS_DIR = os.getenv("MODELS_DIR","/models")
+PIPELINE = os.getenv("PIPELINE", "")
+MODEL_ID = os.getenv("MODEL_ID", "")
+HOST = os.getenv("HOST", "::")
+PORT = os.getenv("PORT", "8000")
+
+def get_download_cmd():
+    include = []
+    exclude = []
+    with open('/app/dl_checkpoints.sh', 'r') as file:
+        lines = file.readlines()  # Reads all lines into a list
+        for line in lines:
+            if MODEL_ID in line:
+                line = line.strip()
+                include_re = re.findall("--include\s+([\*\.\s\w\"]+)(?!\s--\w+)", line)
+                exclude_re = re.findall("--exclude\s+([\*\.\s\w\"]+)(?!\s--\w+)", line)
+                if len(include_re) > 0:
+                    include = ["**/"+s.replace('"', '') for s in include_re[0].split()]
+                if len(exclude_re) > 0:
+                    exclude = ["**/"+s.replace('"', '') for s in exclude_re[0].split()]
+                return include, exclude, MODELS_DIR
+    
+    #no automatic download found
+    return [], [], ""
+
+if __name__ == "__main__":
+    allow, ignore, cache_folder = get_download_cmd()
+    if len(allow) == 0 and len(ignore) == 0:
+        logger.error("no include and exclude files found")
+    
+    #download the model
+    print(f"Downloading model {MODEL_ID} from huggingface")
+    snapshot_download(repo_id=MODEL_ID, cache_dir=cache_folder)
+
+    print(f"Starting ai-runner")
+    with open("/app/app/cfg/uvicorn_logging_config.json", "r") as file:
+        log_config = json.load(file)
+
+    #run the api
+    uvicorn.run(
+        "app.main:app",
+        host=HOST,
+        port=int(PORT),
+        log_config=log_config
+    )
+


### PR DESCRIPTION
This PR adds a special docker build and `salad_app.py` to automatically download the model when the container starts up and then start the API.  

The `Dockerfile.salad` is a pretty simple approach to customize the livepeer runner container to enable auto model downloading and startup after download by using the `livepeer/ai-runner:base` tag by default (or will use `--build-arg BASE_IMAGE=[image tag]` set on launch of `docker build`). SAM2 would start with the `livepeer/ai-runner:segment-anything-2` tag in `BASE_IMAGE`.

**Salad Container Group Setup**

1. Set the Image Source to the docker image built using the Dockerfile.salad included in this PR.
2. Select CPU and memory for the runners.  Suggest 4cpu and 8gb ram minimum. 1 cpu may work but have not tested this yet.  Ram may need to be increased for some models.
3. Choose replica count and GPUs needed.  Size the GPUs based on the model served, if do not know, start with 4090, 3090ti and 3090.  Multiple GPU types can be selected to increase up time of containers.
4. Select 50GB disk
5. Enable Container Gateway. The url provided after enabling this will be the `url` used with the external container in aiModels.json.
6. Setup external logging service. I could not get Axiom to work.  I had better results with NewRelic.
7. Setup environment variables applicable to pipeline and model (see screenshot below).  Host must be `::` to enable the salad gateway to allocate requests to the port.

**Example Environment Variables**
![image](https://github.com/user-attachments/assets/650d321e-645d-491e-bb3f-2a4353e002a4)
