### PR TITLE
(chore) add sam2-hiera-large to beta models download

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -35,6 +35,9 @@ function download_beta_models() {
     # Download audio-to-text models.
     huggingface-cli download openai/whisper-large-v3 --include "*.safetensors" "*.json" --cache-dir models
 
+    # Download custom pipeline models.
+    huggingface-cli download facebook/sam2-hiera-large --include "*.pt" "*.yaml" --cache-dir models
+
     printf "\nDownloading token-gated models...\n"
 
     # Download image-to-video models (token-gated).


### PR DESCRIPTION
This change adds `facebook/sam2-hiera-large` to the beta models section of `dl_checkpoints.sh`

The [docs ](https://docs.livepeer.org/ai/orchestrators/models-download) instruct to use the `--beta` flag when running the bash script, which excludes this model. The change will improve orchestrator experience.