### PR TITLE
Added example_data folder to Dockerfile

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -52,5 +52,6 @@ ENV MODEL_DIR=/models
 COPY app/ /app/app
 COPY images/ /app/images
 COPY bench.py /app/bench.py
+COPY example_data/ /app/example_data
 
 CMD ["uvicorn", "app.main:app", "--log-config", "app/cfg/uvicorn_logging_config.json", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Dockerfile is missing `example_data` folder for bench.py to run. Built and tested the fix with `titannode/ai-runner:example-images`, works as expected.