### PR TITLE
worker: return back error strings to O

### DIFF
--- a/runner/app/routes/image_to_image.py
+++ b/runner/app/routes/image_to_image.py
@@ -7,7 +7,7 @@ import torch
 from app.dependencies import get_pipeline
 from app.pipelines.base import Pipeline
 from app.pipelines.utils.utils import LoraLoadingError
-from app.routes.util import HTTPError, ImageResponse, http_error, image_to_data_url
+from app.routes.util import HTTPError, ImageResponse, http_error, image_to_data_url, handle_pipeline_exception
 from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -184,19 +184,13 @@ async def image_to_image(
             has_nsfw_concept.extend(nsfw_checks)
         except LoraLoadingError as e:
             logger.error(f"ImageToImagePipeline error: {e}")
-            return JSONResponse(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                content=http_error(str(e)),
-            )
+            return handle_pipeline_exception(e, str(e))
         except Exception as e:
             if isinstance(e, torch.cuda.OutOfMemoryError):
                 torch.cuda.empty_cache()
             logger.error(f"ImageToImagePipeline error: {e}")
             logger.exception(e)
-            return JSONResponse(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                content=http_error("ImageToImagePipeline error"),
-            )
+            return handle_pipeline_exception(e, "ImageToImagePipeline error")
 
     # TODO: Return None once Go codegen tool supports optional properties
     # OAPI 3.1 https://github.com/deepmap/oapi-codegen/issues/373

--- a/runner/app/routes/image_to_video.py
+++ b/runner/app/routes/image_to_video.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from app.dependencies import get_pipeline
 from app.pipelines.base import Pipeline
-from app.routes.util import HTTPError, VideoResponse, http_error, image_to_data_url
+from app.routes.util import HTTPError, VideoResponse, http_error, image_to_data_url, handle_pipeline_exception
 from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -153,10 +153,7 @@ async def image_to_video(
     except Exception as e:
         logger.error(f"ImageToVideoPipeline error: {e}")
         logger.exception(e)
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content=http_error("ImageToVideoPipeline error"),
-        )
+        return handle_pipeline_exception(e, "ImageToVideoPipeline error")
 
     output_frames = []
     for frames in batch_frames:

--- a/runner/app/routes/llm.py
+++ b/runner/app/routes/llm.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from app.dependencies import get_pipeline
 from app.pipelines.base import Pipeline
-from app.routes.util import HTTPError, LLMResponse, http_error
+from app.routes.util import HTTPError, LLMResponse, http_error, handle_pipeline_exception
 import json
 
 router = APIRouter()

--- a/runner/app/routes/upscale.py
+++ b/runner/app/routes/upscale.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from app.dependencies import get_pipeline
 from app.pipelines.base import Pipeline
-from app.routes.util import HTTPError, ImageResponse, http_error, image_to_data_url
+from app.routes.util import HTTPError, ImageResponse, http_error, image_to_data_url, handle_pipeline_exception
 from fastapi import APIRouter, Depends, File, Form, UploadFile, status
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -120,10 +120,7 @@ async def upscale(
     except Exception as e:
         logger.error(f"UpscalePipeline error: {e}")
         logger.exception(e)
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content=http_error("UpscalePipeline error"),
-        )
+        return handle_pipeline_exception(e, "UpscalePipeline error")
 
     seeds = [seed]
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -98,7 +98,7 @@ func (w *Worker) TextToImage(ctx context.Context, req GenTextToImageJSONRequestB
 			return nil, err
 		}
 		slog.Error("text-to-image container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("text-to-image container returned 500")
+		return nil, errors.New("text-to-image container returned 500: " + string(val))
 	}
 
 	return resp.JSON200, nil
@@ -128,7 +128,7 @@ func (w *Worker) ImageToImage(ctx context.Context, req GenImageToImageMultipartR
 			return nil, err
 		}
 		slog.Error("image-to-image container returned 422", slog.String("err", string(val)))
-		return nil, errors.New("image-to-image container returned 422")
+		return nil, errors.New("image-to-image container returned 422: " + string(val))
 	}
 
 	if resp.JSON400 != nil {
@@ -146,7 +146,7 @@ func (w *Worker) ImageToImage(ctx context.Context, req GenImageToImageMultipartR
 			return nil, err
 		}
 		slog.Error("image-to-image container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("image-to-image container returned 500")
+		return nil, errors.New("image-to-image container returned 500: " + string(val))
 	}
 
 	return resp.JSON200, nil
@@ -176,7 +176,7 @@ func (w *Worker) ImageToVideo(ctx context.Context, req GenImageToVideoMultipartR
 			return nil, err
 		}
 		slog.Error("image-to-video container returned 422", slog.String("err", string(val)))
-		return nil, errors.New("image-to-video container returned 422")
+		return nil, errors.New("image-to-video container returned 422: " + string(val))
 	}
 
 	if resp.JSON400 != nil {
@@ -185,7 +185,7 @@ func (w *Worker) ImageToVideo(ctx context.Context, req GenImageToVideoMultipartR
 			return nil, err
 		}
 		slog.Error("image-to-video container returned 400", slog.String("err", string(val)))
-		return nil, errors.New("image-to-video container returned 400")
+		return nil, errors.New("image-to-video container returned 400: " + string(val))
 	}
 
 	if resp.JSON500 != nil {
@@ -194,7 +194,7 @@ func (w *Worker) ImageToVideo(ctx context.Context, req GenImageToVideoMultipartR
 			return nil, err
 		}
 		slog.Error("image-to-video container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("image-to-video container returned 500")
+		return nil, errors.New("image-to-video container returned 500: " + string(val))
 	}
 
 	if resp.JSON200 == nil {
@@ -229,7 +229,7 @@ func (w *Worker) Upscale(ctx context.Context, req GenUpscaleMultipartRequestBody
 			return nil, err
 		}
 		slog.Error("upscale container returned 422", slog.String("err", string(val)))
-		return nil, errors.New("upscale container returned 422")
+		return nil, errors.New("upscale container returned 422: " + string(val))
 	}
 
 	if resp.JSON400 != nil {
@@ -238,7 +238,7 @@ func (w *Worker) Upscale(ctx context.Context, req GenUpscaleMultipartRequestBody
 			return nil, err
 		}
 		slog.Error("upscale container returned 400", slog.String("err", string(val)))
-		return nil, errors.New("upscale container returned 400")
+		return nil, errors.New("upscale container returned 400: " + string(val))
 	}
 
 	if resp.JSON500 != nil {
@@ -247,7 +247,7 @@ func (w *Worker) Upscale(ctx context.Context, req GenUpscaleMultipartRequestBody
 			return nil, err
 		}
 		slog.Error("upscale container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("upscale container returned 500")
+		return nil, errors.New("upscale container returned 500: " + string(val))
 	}
 
 	return resp.JSON200, nil
@@ -277,7 +277,7 @@ func (w *Worker) AudioToText(ctx context.Context, req GenAudioToTextMultipartReq
 			return nil, err
 		}
 		slog.Error("audio-to-text container returned 422", slog.String("err", string(val)))
-		return nil, errors.New("audio-to-text container returned 422")
+		return nil, errors.New("audio-to-text container returned 422: " + string(val))
 	}
 
 	if resp.JSON400 != nil {
@@ -286,7 +286,7 @@ func (w *Worker) AudioToText(ctx context.Context, req GenAudioToTextMultipartReq
 			return nil, err
 		}
 		slog.Error("audio-to-text container returned 400", slog.String("err", string(val)))
-		return nil, errors.New("audio-to-text container returned 400")
+		return nil, errors.New("audio-to-text container returned 400: " + string(val))
 	}
 
 	if resp.JSON413 != nil {
@@ -301,7 +301,7 @@ func (w *Worker) AudioToText(ctx context.Context, req GenAudioToTextMultipartReq
 			return nil, err
 		}
 		slog.Error("audio-to-text container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("audio-to-text container returned 500")
+		return nil, errors.New("audio-to-text container returned 500: " + string(val))
 	}
 
 	return resp.JSON200, nil
@@ -366,7 +366,7 @@ func (w *Worker) SegmentAnything2(ctx context.Context, req GenSegmentAnything2Mu
 			return nil, err
 		}
 		slog.Error("segment anything 2 container returned 422", slog.String("err", string(val)))
-		return nil, errors.New("segment anything 2 container returned 422")
+		return nil, errors.New("segment anything 2 container returned 422" + string(val))
 	}
 
 	if resp.JSON400 != nil {
@@ -375,7 +375,7 @@ func (w *Worker) SegmentAnything2(ctx context.Context, req GenSegmentAnything2Mu
 			return nil, err
 		}
 		slog.Error("segment anything 2 container returned 400", slog.String("err", string(val)))
-		return nil, errors.New("segment anything 2 container returned 400")
+		return nil, errors.New("segment anything 2 container returned 400" + string(val))
 	}
 
 	if resp.JSON500 != nil {
@@ -384,7 +384,7 @@ func (w *Worker) SegmentAnything2(ctx context.Context, req GenSegmentAnything2Mu
 			return nil, err
 		}
 		slog.Error("segment anything 2 container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("segment anything 2 container returned 500")
+		return nil, errors.New("segment anything 2 container returned 500" + string(val))
 	}
 
 	return resp.JSON200, nil
@@ -481,7 +481,7 @@ func (w *Worker) handleNonStreamingResponse(c *RunnerContainer, resp *GenLLMResp
 			return nil, err
 		}
 		slog.Error("LLM container returned 400", slog.String("err", string(val)))
-		return nil, errors.New("LLM container returned 400")
+		return nil, errors.New("LLM container returned 400" + string(val))
 	}
 
 	if resp.JSON401 != nil {
@@ -490,7 +490,7 @@ func (w *Worker) handleNonStreamingResponse(c *RunnerContainer, resp *GenLLMResp
 			return nil, err
 		}
 		slog.Error("LLM container returned 401", slog.String("err", string(val)))
-		return nil, errors.New("LLM container returned 401")
+		return nil, errors.New("LLM container returned 401" + string(val))
 	}
 
 	if resp.JSON500 != nil {
@@ -499,7 +499,7 @@ func (w *Worker) handleNonStreamingResponse(c *RunnerContainer, resp *GenLLMResp
 			return nil, err
 		}
 		slog.Error("LLM container returned 500", slog.String("err", string(val)))
-		return nil, errors.New("LLM container returned 500")
+		return nil, errors.New("LLM container returned 500" + string(val))
 	}
 
 	return resp.JSON200, nil


### PR DESCRIPTION
Modifying worker.go:

- Appending the error message to the string that is currently getting sent back to the O and the `Gateway`, so that they can log the proper reasons of failure on the pipelines.

Modifying runner:

- Added an helper under `util.py` in the routes to handle pipeline exception. In this helper, known Exceptions or known patterns can return a humanized `str` as error and the specified status code for the exception. Otherwise, they return either a default error message and status code or the specified error string
- Potentially we could remove this helper and instead have this logic on the Gateway, to have humanized strings to be returned via api response to the requester.
- Currently not edited the llm pipeline, as I see it's returning dicts instead of string. I was unable to check if it's returning dict for a reason or not, to be updated later if we want to handle specific exceptions