### PR TITLE
fix torch device comparison

### DIFF
--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -34,7 +34,7 @@ class AudioToTextPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        if torch_device != "cpu" and has_fp16_variant:
+        if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("AudioToTextPipeline loading fp16 variant for %s", model_id)
 
             kwargs["torch_dtype"] = torch.float16

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -34,6 +34,7 @@ class AudioToTextPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
+        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("AudioToTextPipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -34,7 +34,6 @@ class AudioToTextPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("AudioToTextPipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/image_to_image.py
+++ b/runner/app/pipelines/image_to_image.py
@@ -64,7 +64,7 @@ class ImageToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
-        if torch_device != "cpu" and has_fp16_variant:
+        if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToImagePipeline loading fp16 variant for %s", model_id)
 
             kwargs["torch_dtype"] = torch.float16

--- a/runner/app/pipelines/image_to_image.py
+++ b/runner/app/pipelines/image_to_image.py
@@ -64,6 +64,7 @@ class ImageToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
+        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToImagePipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/image_to_image.py
+++ b/runner/app/pipelines/image_to_image.py
@@ -64,7 +64,6 @@ class ImageToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
-        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToImagePipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/image_to_video.py
+++ b/runner/app/pipelines/image_to_video.py
@@ -33,7 +33,7 @@ class ImageToVideoPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        if torch_device != "cpu" and has_fp16_variant:
+        if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToVideoPipeline loading fp16 variant for %s", model_id)
 
             kwargs["torch_dtype"] = torch.float16

--- a/runner/app/pipelines/image_to_video.py
+++ b/runner/app/pipelines/image_to_video.py
@@ -33,7 +33,6 @@ class ImageToVideoPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToVideoPipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/image_to_video.py
+++ b/runner/app/pipelines/image_to_video.py
@@ -33,6 +33,7 @@ class ImageToVideoPipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
+        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("ImageToVideoPipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -66,7 +66,6 @@ class TextToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
-        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("TextToImagePipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -66,7 +66,7 @@ class TextToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
-        if torch_device != "cpu" and has_fp16_variant:
+        if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("TextToImagePipeline loading fp16 variant for %s", model_id)
 
             kwargs["torch_dtype"] = torch.float16

--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -66,6 +66,7 @@ class TextToImagePipeline(Pipeline):
             )
             or ModelName.SDXL_LIGHTNING.value in model_id
         )
+        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("TextToImagePipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/upscale.py
+++ b/runner/app/pipelines/upscale.py
@@ -36,6 +36,7 @@ class UpscalePipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
+        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("UpscalePipeline loading fp16 variant for %s", model_id)
 

--- a/runner/app/pipelines/upscale.py
+++ b/runner/app/pipelines/upscale.py
@@ -36,7 +36,7 @@ class UpscalePipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        if torch_device != "cpu" and has_fp16_variant:
+        if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("UpscalePipeline loading fp16 variant for %s", model_id)
 
             kwargs["torch_dtype"] = torch.float16

--- a/runner/app/pipelines/upscale.py
+++ b/runner/app/pipelines/upscale.py
@@ -36,7 +36,6 @@ class UpscalePipeline(Pipeline):
             for _, _, files in os.walk(folder_path)
             for fname in files
         )
-        kwargs["torch_dtype"] = torch.float
         if torch_device.type != "cpu" and has_fp16_variant:
             logger.info("UpscalePipeline loading fp16 variant for %s", model_id)
 


### PR DESCRIPTION
[torch.device](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device) is a class not a string, so directly compare them will also result in True

```
torch_device != "cpu" # this is always True, event when torch_device is torch.device('cpu')
```