### PR TITLE
update dev container to expose application port

### DIFF
--- a/runner/.devcontainer/devcontainer.json
+++ b/runner/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 			]
 		}
 	},
-
+        "appPort": ["8000:8000"],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		8000


### PR DESCRIPTION
This change improves developer experience by exposing the application port for ai-worker in the devcontainer config. Useful for debugging across remote systems