### PR TITLE
fix(runner): handle empty prompt in T2I input

### DIFF
--- a/runner/app/routes/text_to_image.py
+++ b/runner/app/routes/text_to_image.py
@@ -156,6 +156,15 @@ async def text_to_image(
     pipeline: Pipeline = Depends(get_pipeline),
     token: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
 ):
+    # Ensure required parameters are non-empty.
+    # TODO: Remove if go-livepeer validation is fixed. Was disabled due to optional
+    # params issue.
+    if not params.prompt:
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content=http_error("Prompt must be provided."),
+        )
+
     auth_token = os.environ.get("AUTH_TOKEN")
     if auth_token:
         if not token or token.credentials != auth_token:


### PR DESCRIPTION
This pull request adds a check to the T2I route to ensure the 'prompt' input value is non-empty. This is necessary because request body validation was disabled in go-livepeer due to issues with optional parameters not showing up correctly.
See [this go-livepeer commit](https://github.com/livepeer/go-livepeer/commit/3fcc300b42a0e758ebe63f2599a5556a5bd95390) for more details.
