### PR TITLE
runner/live: Fix params API params piping

### DIFF
--- a/runner/app/live/params_api/api.py
+++ b/runner/app/live/params_api/api.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 import tempfile
 import time
+from typing import cast
 
 from aiohttp import BodyPartReader, web
 
@@ -57,7 +58,9 @@ async def handle_params_update(request):
         else:
             raise ValueError(f"Unknown content type: {request.content_type}")
 
-        request.app["handler"].update_params(params)
+        handler = cast(PipelineStreamer, request.app["handler"])
+        handler.update_params(**params)
+
         return web.Response(text="Params updated successfully")
     except Exception as e:
         logging.error(f"Error updating params: {e}")

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -56,11 +56,11 @@ class PipelineStreamer(ABC):
             logging.error(f"Error restarting pipeline process: {e}")
             logging.error(f"Stack trace:\n{traceback.format_exc()}")
 
-    def update_params(self, params: dict):
+    def update_params(self, **params):
         self.params = params
         self.last_params_time = time.time()
         if self.process:
-            self.process.update_params(params)
+            self.process.update_params(**params)
 
     async def monitor_loop(self, done: Event):
         start_time = time.time()


### PR DESCRIPTION
There were some kwargs that were passed as args etc, made them consistent on all the stack.