### PR TITLE
Remove gstreamer from live-multimedia Dockerfile

### DIFF
--- a/runner/docker/Dockerfile.live-multimedia
+++ b/runner/docker/Dockerfile.live-multimedia
@@ -44,30 +44,5 @@ RUN cd ffmpeg && \
 # Copy the compiled FFmpeg binaries to /usr/local
 RUN cp -R /compiled/* /usr/local/
 
-# Install necessary dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libgstreamer1.0-dev \
-    libgstreamer-plugins-base1.0-dev \
-    libgstreamer-plugins-bad1.0-dev \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-bad \
-    gstreamer1.0-plugins-ugly \
-    gstreamer1.0-libav \
-    gstreamer1.0-tools \
-    gstreamer1.0-x \
-    gstreamer1.0-alsa \
-    gstreamer1.0-gl \
-    gstreamer1.0-gtk3 \
-    gstreamer1.0-qt5 \
-    gstreamer1.0-pulseaudio \
-    libgstrtspserver-1.0-dev \
-    libgirepository1.0-dev \
-    python3-gst-1.0
-
 # Clean up APT cache to reduce image size
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set environment variables for GStreamer
-ENV GST_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/gstreamer-1.0
-ENV GST_PLUGIN_SCANNER=/usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner


### PR DESCRIPTION
Installing it takes a long time and it is no longer needed as far as I can tell.
This should reduce the image size significantly as well.