### PR TITLE
live/infer: Add trickle input and output

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -86,7 +86,10 @@ if __name__ == "__main__":
         logging.error(f"Error parsing --initial-params: {e}")
         sys.exit(1)
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S')
 
     try:
         asyncio.run(

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -79,6 +79,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--publish-url", type=str, required=True, help="url to push outgoing streams"
     )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose (debug) logging"
+    )
     args = parser.parse_args()
     try:
         params = json.loads(args.initial_params)
@@ -86,10 +91,13 @@ if __name__ == "__main__":
         logging.error(f"Error parsing --initial-params: {e}")
         sys.exit(1)
 
+    log_level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(
         format='%(asctime)s %(levelname)-8s %(message)s',
-        level=logging.INFO,
+        level=log_level,
         datefmt='%Y-%m-%d %H:%M:%S')
+    if args.verbose:
+        os.environ['VERBOSE_LOGGING'] = '1' # enable verbose logging in subprocesses
 
     try:
         asyncio.run(

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     try:
         asyncio.run(
-            main(args.http_port, args.input_address, args.output_address, args.pipeline, args.subscribe_url, args.publish_url, params)
+            main(args.http_port, args.subscribe_url, args.publish_url, args.pipeline, params)
         )
     except Exception as e:
         logging.error(f"Fatal error in main: {e}")

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -5,7 +5,6 @@ import logging
 import signal
 import sys
 import os
-import queue
 import traceback
 from typing import List
 
@@ -14,27 +13,14 @@ infer_root = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, infer_root)
 
 from params_api import start_http_server
-from streamer.zeromq import ZeroMQStreamer
+from streamer.trickle import TrickleStreamer
 
-import trickle
 
-async def main(http_port: int, input_address: str, output_address: str, pipeline: str, subscribe_url: str, publish_url: str, params: dict):
-    handler = ZeroMQStreamer(input_address, output_address, pipeline, **(params or {}))
+async def main(http_port: int, subscribe_url: str, publish_url: str, pipeline: str, params: dict):
+    handler = TrickleStreamer(subscribe_url, publish_url, pipeline, **(params or {}))
     runner = None
-    image_queue = queue.Queue()
-    def image_callback(image):
-        # TODO send image to inference
-        # For now just loop it back into the output
-        if image:
-            logging.info(f"Received JPEG of length {len(image)} bytes")
-        else:
-            logging.info("Empty image in queue, shutting down")
-        image_queue.put(image) # use None to signal shutdown
-
     try:
         handler.start()
-        subscribe_task = asyncio.create_task(trickle.run_subscribe(subscribe_url, image_callback))
-        publish_task = asyncio.create_task(trickle.run_publish(publish_url, image_queue))
         runner = await start_http_server(handler, http_port)
     except Exception as e:
         logging.error(f"Error starting socket handler or HTTP server: {e}")
@@ -43,8 +29,6 @@ async def main(http_port: int, input_address: str, output_address: str, pipeline
 
     await block_until_signal([signal.SIGINT, signal.SIGTERM])
     try:
-        await subscribe_task
-        await publish_task
         await runner.cleanup()
         await handler.stop()
     except Exception as e:

--- a/runner/app/live/streamer/jpeg.py
+++ b/runner/app/live/streamer/jpeg.py
@@ -1,0 +1,17 @@
+import io
+from PIL import Image
+
+
+def to_jpeg_bytes(frame: Image.Image):
+    buffer = io.BytesIO()
+    frame.save(buffer, format="JPEG")
+    bytes = buffer.getvalue()
+    buffer.close()
+    return bytes
+
+
+def from_jpeg_bytes(frame_bytes: bytes):
+    image = Image.open(io.BytesIO(frame_bytes))
+    if image.mode != "RGBA":
+        image = image.convert("RGBA")
+    return image

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -64,6 +64,7 @@ class PipelineProcess:
     async def recv_output(self) -> Image.Image | None:
         # we cannot do a long get with timeout as that would block the asyncio
         # event loop, so we loop with nowait and sleep async instead.
+        # TODO: use asyncio.to_thread instead
         while not self.is_done():
             try:
                 output = self.output_queue.get_nowait()

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 import multiprocessing as mp
@@ -76,7 +77,12 @@ class PipelineProcess:
         return None
 
     def process_loop(self):
-        logging.basicConfig(level=logging.INFO)
+        level = logging.DEBUG if os.environ.get('VERBOSE_LOGGING') == '1' else logging.INFO
+        logging.basicConfig(
+            format='%(asctime)s %(levelname)-8s %(message)s',
+            level=level,
+            datefmt='%Y-%m-%d %H:%M:%S')
+
         try:
             params = {}
             try:
@@ -106,7 +112,6 @@ class PipelineProcess:
                 try:
                     input_image = self.input_queue.get(timeout=0.1)
                 except queue.Empty:
-                    logging.debug("Input queue empty")
                     continue
 
                 try:

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -82,8 +82,11 @@ class PipelineStreamer(ABC):
                 return
 
             current_time = time.time()
-            time_since_last_input = current_time - self.process.last_input_time
-            time_since_last_output = current_time - self.process.last_output_time
+            last_input_time = self.process.last_input_time or start_time
+            last_output_time = self.process.last_output_time or start_time
+
+            time_since_last_input = current_time - last_input_time
+            time_since_last_output = current_time - last_output_time
             time_since_start = current_time - start_time
             time_since_last_params = current_time - self.last_params_time
             time_since_reload = min(time_since_last_params, time_since_start)

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -58,6 +58,7 @@ class PipelineStreamer(ABC):
         except Exception as e:
             logging.error(f"Error restarting pipeline process: {e}")
             logging.error(f"Stack trace:\n{traceback.format_exc()}")
+            exit(1)
 
     def update_params(self, **params):
         self.params = params

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -84,6 +84,7 @@ class PipelineStreamer(ABC):
             current_time = time.time()
             last_input_time = self.process.last_input_time or start_time
             last_output_time = self.process.last_output_time or start_time
+            logging.debug(f"Monitoring process. last_input_time: {last_input_time}, last_output_time: {last_output_time} last_params_time: {self.last_params_time}")
 
             time_since_last_input = current_time - last_input_time
             time_since_last_output = current_time - last_output_time
@@ -120,6 +121,7 @@ class PipelineStreamer(ABC):
             async for frame in self.ingress_loop(done):
                 if done.is_set() or not self.process:
                     return
+                logging.debug(f"Sending input frame. width: {frame.width}, height: {frame.height}")
                 self.process.send_input(frame)
 
                 # Increment frame count and measure FPS

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -22,6 +22,9 @@ class PipelineStreamer(ABC):
         self.restart_count = 0
 
     def start(self):
+        if self.process:
+            raise RuntimeError("PipelineProcess already started")
+
         self.process = PipelineProcess.start(self.pipeline, **self.params)
         self.ingress_task = asyncio.create_task(self.run_ingress_loop(self.process.done))
         self.egress_task = asyncio.create_task(self.run_egress_loop(self.process.done))

--- a/runner/app/live/streamer/trickle.py
+++ b/runner/app/live/streamer/trickle.py
@@ -1,0 +1,56 @@
+import asyncio
+import queue
+
+from PIL import Image
+from multiprocessing.synchronize import Event
+from typing import AsyncGenerator
+
+from trickle import media
+
+from .streamer import PipelineStreamer
+from .jpeg import to_jpeg_bytes, from_jpeg_bytes
+
+class TrickleStreamer(PipelineStreamer):
+    def __init__(
+        self,
+        subscribe_url: str,
+        publish_url: str,
+        pipeline: str,
+        **params,
+    ):
+        super().__init__(pipeline, **params)
+        self.subscribe_url = subscribe_url
+        self.publish_url = publish_url
+        self.subscribe_queue = queue.Queue[bytearray]()
+        self.publish_queue = queue.Queue[bytearray]()
+
+    def start(self):
+        self.subscribe_task = asyncio.create_task(media.run_subscribe(self.subscribe_url, self.subscribe_queue.put))
+        self.publish_task = asyncio.create_task(media.run_publish(self.publish_url, self.publish_queue))
+        super().start()
+
+    async def stop(self):
+        await super().stop()
+        self.subscribe_queue.put(None)
+        self.publish_queue.put(None)
+
+    async def ingress_loop(self, done: Event) -> AsyncGenerator[Image.Image, None]:
+        def dequeue_jpeg():
+            jpeg_bytes = self.subscribe_queue.get()
+            if not jpeg_bytes:
+                return None
+            return from_jpeg_bytes(jpeg_bytes)
+
+        while not done.is_set():
+            image = await asyncio.to_thread(dequeue_jpeg)
+            if not image:
+                break
+            yield image
+
+    async def egress_loop(self, output_frames: AsyncGenerator[Image.Image, None]):
+        def enqueue_bytes(frame: Image.Image):
+            jpeg_bytes = to_jpeg_bytes(frame)
+            self.publish_queue.put(jpeg_bytes)
+
+        async for frame in output_frames:
+            await asyncio.to_thread(enqueue_bytes, frame)

--- a/runner/app/live/streamer/trickle.py
+++ b/runner/app/live/streamer/trickle.py
@@ -26,7 +26,7 @@ class TrickleStreamer(PipelineStreamer):
 
     def start(self):
         self.subscribe_task = asyncio.create_task(media.run_subscribe(self.subscribe_url, self.subscribe_queue.put))
-        self.publish_task = asyncio.create_task(media.run_publish(self.publish_url, self.publish_queue))
+        self.publish_task = asyncio.create_task(media.run_publish(self.publish_url, self.publish_queue.get))
         super().start()
 
     async def stop(self):

--- a/runner/app/live/streamer/trickle.py
+++ b/runner/app/live/streamer/trickle.py
@@ -40,7 +40,7 @@ class TrickleStreamer(PipelineStreamer):
         self.publish_queue.put(None)
 
         try:
-            await asyncio.wait([self.subscribe_task, self.publish_task], timeout=15.0)
+            await asyncio.wait([self.subscribe_task, self.publish_task], timeout=30.0)
         except asyncio.TimeoutError:
             self.subscribe_task.cancel()
             self.publish_task.cancel()

--- a/runner/app/live/streamer/trickle.py
+++ b/runner/app/live/streamer/trickle.py
@@ -26,8 +26,11 @@ class TrickleStreamer(PipelineStreamer):
         self.publish_queue = queue.Queue[bytearray]()
 
     def start(self):
-        self.subscribe_task = asyncio.create_task(media.run_subscribe(self.subscribe_url, self.subscribe_queue.put))
-        self.publish_task = asyncio.create_task(media.run_publish(self.publish_url, self.publish_queue.get))
+        subscribe_put = lambda m: asyncio.to_thread(self.subscribe_queue.put, m)
+        publish_get = lambda: asyncio.to_thread(self.publish_queue.get)
+
+        self.subscribe_task = asyncio.create_task(media.run_subscribe(self.subscribe_url, subscribe_put))
+        self.publish_task = asyncio.create_task(media.run_publish(self.publish_url, publish_get))
         super().start()
 
     async def stop(self):

--- a/runner/app/live/streamer/zeromq.py
+++ b/runner/app/live/streamer/zeromq.py
@@ -6,21 +6,7 @@ from multiprocessing.synchronize import Event
 from typing import AsyncGenerator
 
 from .streamer import PipelineStreamer
-
-
-def to_jpeg_bytes(frame: Image.Image):
-    buffer = io.BytesIO()
-    frame.save(buffer, format="JPEG")
-    bytes = buffer.getvalue()
-    buffer.close()
-    return bytes
-
-
-def from_jpeg_bytes(frame_bytes: bytes):
-    image = Image.open(io.BytesIO(frame_bytes))
-    if image.mode != "RGBA":
-        image = image.convert("RGBA")
-    return image
+from .jpeg import to_jpeg_bytes, from_jpeg_bytes
 
 
 class ZeroMQStreamer(PipelineStreamer):

--- a/runner/app/live/trickle/__init__.py
+++ b/runner/app/live/trickle/__init__.py
@@ -1,0 +1,3 @@
+from .media import run_subscribe, run_publish
+
+__all__ = ["run_subscribe", "run_publish"]

--- a/runner/app/live/trickle/jpeg_parser.py
+++ b/runner/app/live/trickle/jpeg_parser.py
@@ -1,0 +1,60 @@
+import io
+import os
+import sys
+import logging
+
+class JPEGStreamParser:
+    def __init__(self, callback):
+        """
+        Initializes the JPEGStreamParser.
+        :param callback: Function to be called when a complete JPEG is found. Receives bytes of the JPEG image.
+        """
+        self.buffer = bytearray()
+        self.callback = callback
+        self.in_jpeg = False
+        self.start_idx = 0  # Keep track of the start index across feeds
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exec_type, exec_val, exec_tb):
+        logging.info("JOSH closing jpeg parser via exit")
+        self.close()
+
+    def close(self):
+        logging.info("Closing jpeg parser")
+        self.callback(None)
+
+    def feed(self, data):
+        """
+        Feed incoming data into the parser.
+        :param data: Incoming data bytes.
+        """
+        self.buffer.extend(data)
+
+        while True:
+            # Find the start marker (0xFFD8) if not already in JPEG
+            if not self.in_jpeg:
+                self.start_idx = self.buffer.find(b'\xff\xd8', self.start_idx)
+                if self.start_idx == -1:
+                    # No start marker found, buffer the data for later.
+                    self.start_idx = max(0, len(self.buffer) - 1)  # Move to the end of the buffer to prevent unnecessary re-scanning
+                    return
+                self.in_jpeg = True
+                self.start_idx += 2  # Move past the start marker
+
+            # Look for the end marker (0xFFD9)
+            end_idx = self.buffer.find(b'\xff\xd9', self.start_idx)
+            if end_idx == -1:
+                # No end marker found, keep buffering
+                self.start_idx = max(0, len(self.buffer) - 1)  # Move to the end of the buffer to prevent unnecessary re-scanning
+                return
+
+            # Extract the JPEG and call the callback
+            jpeg_data = self.buffer[:end_idx + 2]
+            self.callback(jpeg_data)
+
+            # Remove the processed JPEG from the buffer
+            self.buffer = self.buffer[end_idx + 2:]
+            self.in_jpeg = False
+            self.start_idx = 0  # Reset start_idx to begin from the start of the updated buffer

--- a/runner/app/live/trickle/jpeg_parser.py
+++ b/runner/app/live/trickle/jpeg_parser.py
@@ -1,6 +1,4 @@
-import io
-import os
-import sys
+import asyncio
 import logging
 
 class JPEGStreamParser:
@@ -52,7 +50,8 @@ class JPEGStreamParser:
 
             # Extract the JPEG and call the callback
             jpeg_data = self.buffer[:end_idx + 2]
-            self.callback(jpeg_data)
+            # Callback may be a blocking function (like Queue.get) so run it in a thread
+            await asyncio.to_thread(self.callback, jpeg_data)
 
             # Remove the processed JPEG from the buffer
             self.buffer = self.buffer[end_idx + 2:]

--- a/runner/app/live/trickle/jpeg_parser.py
+++ b/runner/app/live/trickle/jpeg_parser.py
@@ -25,7 +25,7 @@ class JPEGStreamParser:
         logging.info("Closing jpeg parser")
         self.callback(None)
 
-    def feed(self, data):
+    async def feed(self, data):
         """
         Feed incoming data into the parser.
         :param data: Incoming data bytes.

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -118,7 +118,7 @@ async def parse_jpegs(in_pipe, image_callback):
             chunk = await in_pipe.read(chunk_size)
             if not chunk:
                 break
-            parser.feed(chunk)
+            await parser.feed(chunk)
 
 def feed_ffmpeg(ffmpeg_fd, image_generator):
     while True:
@@ -173,6 +173,7 @@ async def run_publish(publish_url: str, image_generator):
         ffmpeg_feeder = threading.Thread(target=feed_ffmpeg, args=(ffmpeg_write_fd, image_generator))
         segment_thread.start()
         ffmpeg_feeder.start()
+        logging.debug("run_publish: ffmpeg feeder and segmenter threads started")
 
         def joins():
             segment_thread.join()

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -122,7 +122,7 @@ async def parse_jpegs(in_pipe, image_callback):
 
 def feed_ffmpeg(ffmpeg_fd, image_generator):
     while True:
-        image = image_generator.get()
+        image = image_generator()
         if image is None:
             logging.info("Image generator empty, leaving feed_ffmpeg")
             break

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -1,0 +1,187 @@
+import aiohttp
+import asyncio
+import logging
+import os
+import threading
+import subprocess
+
+from .trickle_subscriber import TrickleSubscriber
+from .trickle_publisher import TricklePublisher
+from .jpeg_parser import JPEGStreamParser
+from . import segmenter
+
+# target framerate
+FRAMERATE=segmenter.FRAMERATE
+GOP_SECS=segmenter.GOP_SECS
+
+# TODO make this better configurable
+GPU=segmenter.GPU
+
+async def run_subscribe(subscribe_url: str, image_callback):
+    # TODO add some pre-processing parameters, eg image size
+    try:
+        ffmpeg = await launch_ffmpeg()
+        logging_task = asyncio.create_task(log_pipe_async(ffmpeg.stderr))
+        subscribe_task = asyncio.create_task(subscribe(subscribe_url, ffmpeg.stdin))
+        jpeg_task = asyncio.create_task(parse_jpegs(ffmpeg.stdout, image_callback))
+        await asyncio.gather(ffmpeg.wait(), logging_task, subscribe_task, jpeg_task)
+    except Exception as e:
+        logging.error(f"preprocess got error {e}", e)
+        raise e
+
+async def subscribe(subscribe_url, out_pipe):
+    subscriber = TrickleSubscriber(url=subscribe_url)
+    logging.info(f"JOSH - launching subscribe loop for {subscribe_url}")
+    while True:
+        segment = None
+        try:
+            segment = await subscriber.next()
+            if not segment:
+                break # complete
+            while True:
+                chunk = await segment.read()
+                if not chunk:
+                    break # end of segment
+                out_pipe.write(chunk)
+                await out_pipe.drain()
+        except aiohttp.ClientError as e:
+            logging.info(f"Failed to read segment - {e}")
+            break # end of stream?
+        except Exception as e:
+            raise e
+        finally:
+            if segment:
+                await segment.close()
+            else:
+                # stream is complete
+                out_pipe.close()
+                break
+
+async def launch_ffmpeg():
+    if GPU:
+        ffmpeg_cmd = [
+        'ffmpeg',
+	    '-loglevel', 'warning',
+	    '-hwaccel', 'cuda',
+	    '-hwaccel_output_format', 'cuda',
+        '-i', 'pipe:0',       # Read input from stdin
+	    '-an',
+	    '-vf', 'scale_cuda=w=512:h=512:force_original_aspect_ratio=decrease:force_divisible_by=2,hwdownload,format=nv12,fps={FRAMERATE}'
+	    '-c:v', 'mjpeg',
+	    '-start_number', '0',
+	    '-q:v', '1',
+        '-f', 'image2pipe',
+        'pipe:1'              # Output to stdout
+        ]
+    else:
+        ffmpeg_cmd = [
+        'ffmpeg',
+	    '-loglevel', 'warning',
+        '-i', 'pipe:0',       # Read input from stdin
+	    '-an',
+	    '-vf', f'scale=w=512:h=512:force_original_aspect_ratio=decrease:force_divisible_by=2,fps={FRAMERATE}',
+	    '-c:v', 'mjpeg',
+	    '-start_number', '0',
+	    '-q:v', '1',
+        '-f', 'image2pipe',
+        'pipe:1'              # Output to stdout
+        ]
+
+    logging.info(f"ffmpeg (input) {ffmpeg_cmd}")
+    # Launch FFmpeg process with stdin, stdout, and stderr as pipes
+    process = await asyncio.create_subprocess_exec(
+        *ffmpeg_cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    return process  # Return the process handle
+
+async def log_pipe_async(pipe):
+    """Reads from a pipe and logs each line."""
+    while True:
+        line = await pipe.readline()
+        if not line:
+            break  # Exit when the pipe is closed
+        # Decode the binary line and log it
+        logging.info(line.decode().strip())
+
+async def parse_jpegs(in_pipe, image_callback):
+    chunk_size = 32 * 1024 # read in 32kb chunks
+    with JPEGStreamParser(image_callback) as parser:
+        # TODO this does not work on asyncio streams - figure out how to
+        #      disable os buffering on readsdisable buffering on reads
+        #pipe = os.fdopen(in_pipe.fileno(), 'rb', buffering=0)
+        while True:
+            chunk = await in_pipe.read(chunk_size)
+            if not chunk:
+                break
+            parser.feed(chunk)
+
+def feed_ffmpeg(ffmpeg_fd, image_generator):
+    with os.fdopen(ffmpeg_fd, 'wb', buffering=0) as ffmpeg:
+        while True:
+            image = image_generator.get()
+            if image is None:
+                logging.info("Image generator empty, leaving feed_ffmpeg")
+                break
+            ffmpeg.write(image)
+            ffmpeg.flush()
+
+async def run_publish(publish_url: str, image_generator):
+    try:
+        publisher = TricklePublisher(url=publish_url, mime_type="video/mp2t")
+
+        loop = asyncio.get_running_loop()
+        async def callback(pipe_file, pipe_name):
+            # trickle publish a segment with the contents of `pipe_file`
+            async with await publisher.next() as segment:
+                # convert pipe_fd into an asyncio friendly StreamReader
+                reader = asyncio.StreamReader()
+                protocol = asyncio.StreamReaderProtocol(reader)
+                transport, _ = await loop.connect_read_pipe(lambda: protocol, pipe_file)
+                while True:
+                    sz = 32 * 1024 # read in chunks of 32KB
+                    data = await reader.read(sz)
+                    if not data:
+                        break
+                    await segment.write(data)
+                transport.close()
+
+        def sync_callback(pipe_fd, pipe_name):
+            # asyncio.connect_read_pipe expects explicit fd close
+            # so we have to manually read, detect eof, then close
+            r, w = os.pipe()
+            rf = os.fdopen(r, 'rb', buffering=0)
+            future = asyncio.run_coroutine_threadsafe(callback(rf, pipe_name), loop)
+            try:
+                while True:
+                    data = pipe_fd.read(32 * 1024)
+                    if not data:
+                        break
+                    os.write(w, data)
+                os.close(w) # streamreader is very sensitive about this
+                future.result()  # This blocks in the thread until callback completes
+                rf.close() # also closes the read end of the pipe
+            # Ensure any exceptions in the coroutine are caught
+            except Exception as e:
+                logging.error(f"Error in sync_callback: {e}")
+
+        ffmpeg_read_fd, ffmpeg_write_fd = os.pipe()
+        segment_thread = threading.Thread(target=segmenter.segment_reading_process, args=(ffmpeg_read_fd, sync_callback))
+        ffmpeg_feeder = threading.Thread(target=feed_ffmpeg, args=(ffmpeg_write_fd, image_generator))
+        segment_thread.start()
+        ffmpeg_feeder.start()
+
+        def joins():
+            segment_thread.join()
+            ffmpeg_feeder.join()
+        await asyncio.to_thread(joins)
+        logging.info("postprocess complete")
+
+    except Exception as e:
+        logging.error(f"postprocess got error {e}", e)
+        raise e
+    finally:
+        await publisher.close()

--- a/runner/app/live/trickle/segmenter.py
+++ b/runner/app/live/trickle/segmenter.py
@@ -11,7 +11,7 @@ import threading
 from datetime import datetime
 
 # Constants and initial values
-READ_TIMEOUT = 20
+READ_TIMEOUT = 90
 SLEEP_INTERVAL = 0.05
 
 # TODO make this better configurable
@@ -128,6 +128,7 @@ def segment_reading_process(in_fd, callback):
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
+    logging.debug("segment_reading_process: ffmpeg started")
 
     # Create a thread to handle stderr redirection
     thread = threading.Thread(target=print_proc, args=(proc.stdout,))

--- a/runner/app/live/trickle/segmenter.py
+++ b/runner/app/live/trickle/segmenter.py
@@ -1,0 +1,186 @@
+import errno
+import time
+import logging
+import os
+import select
+import string
+import subprocess
+import sys
+import random
+import threading
+from datetime import datetime
+
+# Constants and initial values
+READ_TIMEOUT = 2
+SLEEP_INTERVAL = 0.05
+
+# TODO make this better configurable
+FRAMERATE=24
+GOP_SECS=3
+GPU=False
+
+def create_named_pipe(pattern, pipe_index):
+    pipe_name = pattern % pipe_index
+    try:
+        os.mkfifo(pipe_name)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    return pipe_name
+
+def remove_named_pipe(pipe_name):
+    try:
+        os.remove(pipe_name)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+def ffmpeg_cmd(in_pipe_fd, out_pattern):
+
+    if GPU:
+        cmd = [
+        'ffmpeg',
+	    '-loglevel', 'warning',
+        '-f', 'image2pipe',
+        '-framerate', f"{FRAMERATE}",
+        '-i', f'pipe:{in_pipe_fd}',
+        '-c:v', 'h264_nvenc',
+        '-bf', '0', # disable bframes for webrtc
+        '-g', f'{GOP_SECS*FRAMERATE}',
+        '-preset', 'p1',
+        '-tune', 'ull',
+        '-f', 'segment',
+        out_pattern
+        ]
+    else:
+        cmd = [
+        'ffmpeg',
+	    '-loglevel', 'info',
+        '-f', 'image2pipe',
+        '-framerate', f"{FRAMERATE}",
+        '-i', f'pipe:{in_pipe_fd}',
+        #'-i', f'-', # stdin
+        '-c:v', 'libx264',
+        '-bf', '0', # disable bframes for webrtc
+        '-g', f'{GOP_SECS*FRAMERATE}',
+        '-preset', 'superfast',
+        '-tune', 'zerolatency',
+        '-f', 'segment',
+        out_pattern
+        ]
+
+    logging.info(f"JOSH - ffmpeg (output) {cmd}")
+    return cmd
+
+
+def read_from_pipe(pipe_name, callback, ffmpeg_proc):
+    fd = os.open(pipe_name, os.O_RDONLY | os.O_NONBLOCK)
+
+    # Polling to check if the pipe is ready
+    poller = select.poll()
+    poller.register(fd, select.POLLIN)
+
+    start_time = time.time()
+    while True:
+        # Wait for the pipe to become ready for reading
+        events = poller.poll(1000 * SLEEP_INTERVAL)
+
+        # If the pipe is ready, switch to blocking mode and read
+        if events:
+            os.set_blocking(fd, True)
+            break
+
+        # Check if ffmpeg has exited after polling
+        if ffmpeg_proc.poll() is not None:
+            logging.info(f"FFmpeg process has exited while waiting for pipe {pipe_name}")
+            os.close(fd)
+            return False
+
+
+        # Check if we've exceeded the timeout
+        if time.time() - start_time > READ_TIMEOUT:
+            logging.info(f"Timeout waiting for pipe {pipe_name}")
+            os.close(fd)
+            return False
+
+        # Sleep briefly before checking again
+        time.sleep(SLEEP_INTERVAL)
+
+    # Now that the pipe is ready, invoke the callback
+    # fdopen will implcitly close the supplied fd
+    with os.fdopen(fd, 'rb', buffering=0) as pipe_fd:
+        callback(pipe_fd, pipe_name)
+
+    remove_named_pipe(pipe_name)
+    return True
+
+def segment_reading_process(in_fd, callback):
+    logging.info("JOSH - in segment reading process")
+    pipe_index = 0
+    out_pattern = generate_random_string() + "-%d.ts"
+
+    # Start by creating the first two named pipes
+    current_pipe = create_named_pipe(out_pattern, pipe_index)
+    next_pipe = create_named_pipe(out_pattern, pipe_index + 1)
+
+    # Launch FFmpeg process with stdin, stdout, and stderr as pipes
+    proc = subprocess.Popen(
+        ffmpeg_cmd(in_fd, out_pattern),
+        stdin=subprocess.PIPE,
+        #stdin=in_fd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        pass_fds=(in_fd,),
+    )
+
+    # Create a thread to handle stderr redirection
+    thread = threading.Thread(target=print_proc, args=(proc.stderr,))
+    thread.start()
+    thread2 = threading.Thread(target=print_proc, args=(proc.stdout,))
+    thread2.start()
+
+    try:
+        while True:
+            # Read from the current pipe, exit the loop if there's a timeout or ffmpeg exit
+            if not read_from_pipe(current_pipe, callback, proc):
+                logging.info("Exiting ffmpeg (output) due to timeout or process exit.")
+                break
+
+            # Move to the next pipes in the sequence
+            pipe_index += 1
+            current_pipe = next_pipe
+
+            # Create the new next pipe in the sequence
+            next_pipe = create_named_pipe(out_pattern, pipe_index + 1)
+
+    except Exception as e:
+        logging.info(f"FFmpeg (output) error : {e} - {current_pipe}")
+
+    finally:
+        os.close(in_fd)
+        #proc.stdin.close()
+        logging.info("awaitng ffmpeg (output)")
+        proc.wait()
+        logging.info("proc complete ffmpeg (output)")
+        thread.join()
+        thread2.join()
+        logging.info("ffmpeg (output) complete")
+        #(stdout, stderr) = proc.communicate()
+        #logging.info("FFmpeg (output)")
+        #logging.info(stderr.decode())
+        #logging.info(stdout.decode())
+
+        # Cleanup remaining pipes
+        remove_named_pipe(current_pipe)
+        remove_named_pipe(next_pipe)
+
+def print_proc(f):
+    """Reads stderr from a subprocess and writes it to sys.stderr."""
+    for line in iter(f.readline, b''):
+        sys.stderr.write(line.decode())
+
+def generate_random_string():
+    """Generates a random string of length 5."""
+    length=5
+    letters = string.ascii_letters + string.digits
+    return ''.join(random.choice(letters) for i in range(length))

--- a/runner/app/live/trickle/trickle_publisher.py
+++ b/runner/app/live/trickle/trickle_publisher.py
@@ -1,0 +1,115 @@
+import asyncio
+import aiohttp
+import logging
+from contextlib import asynccontextmanager
+
+class TricklePublisher:
+    def __init__(self, url: str, mime_type: str):
+        self.url = url
+        self.mime_type = mime_type
+        self.idx = 0  # Start index for POSTs
+        self.next_writer = None
+        self.lock = asyncio.Lock()  # Lock to manage concurrent access
+        self.session = aiohttp.ClientSession()
+
+    async def __aenter__(self):
+        """Enter context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """Exit context manager and close the session."""
+        await self.close()
+
+    def streamIdx(self):
+        return f"{self.url}/{self.idx}"
+
+    async def preconnect(self):
+        """Preconnect to the server by initiating a POST request to the current index."""
+        url = self.streamIdx()
+        logging.info(f"Preconnecting to URL: {url}")
+        try:
+            # we will be incrementally writing data into this queue
+            queue = asyncio.Queue()
+            asyncio.create_task(self._run_post(url, queue))
+            return queue
+        except aiohttp.ClientError as e:
+            logging.error(f"Failed to complete POST for {self.streamIdx()}: {e}")
+            return None
+
+    async def _run_post(self, url, queue):
+        try:
+            resp = await self.session.post(
+                url,
+                headers={'Connection': 'close', 'Content-Type': self.mime_type},
+                data=self._stream_data(queue)
+            )
+            # TODO propagate errors?
+            if resp.status != 200:
+                body = await resp.text()
+                logging.error(f"Trickle POST failed {self.streamIdx()}, status code: {resp.status}, msg: {body}")
+        except Exception as e:
+            logging.error(f"Trickle POST  exception {self.streamIdx()} - {e}")
+        return None
+
+    async def _stream_data(self, queue):
+        """Stream data from the queue for the POST request."""
+        while True:
+            chunk = await queue.get()
+            if chunk is None:  # Stop signal
+                break
+            yield chunk
+
+    async def next(self):
+        """Start or retrieve a pending POST request and preconnect for the next segment."""
+        async with self.lock:
+            if self.next_writer is None:
+                logging.info(f"No pending connection, preconnecting {self.streamIdx()}...")
+                self.next_writer = await self.preconnect()
+
+            writer = self.next_writer
+            self.next_writer = None
+
+            # Set up the next POST in the background
+            asyncio.create_task(self._preconnect_next_segment())
+
+        return SegmentWriter(writer)
+
+    async def _preconnect_next_segment(self):
+        """Preconnect to the next POST in the background."""
+        logging.info(f"Setting up next connection for {self.streamIdx()}")
+        async with self.lock:
+            if self.next_writer is not None:
+                return
+            self.idx += 1  # Increment the index for the next POST
+            next_writer = await self.preconnect()
+            if next_writer:
+                self.next_writer = next_writer
+
+    async def close(self):
+        """Close the session when done."""
+        logging.info(f"Closing {self.url}")
+        if self.next_writer:
+            s = SegmentWriter(self.next_writer)
+            await s.close()
+        await self.session.delete(self.url)
+        await self.session.close()
+
+class SegmentWriter:
+    def __init__(self, queue: asyncio.Queue):
+        self.queue = queue
+
+    async def write(self, data):
+        """Write data to the current segment."""
+        await self.queue.put(data)
+
+    async def close(self):
+        """Ensure the request is properly closed when done."""
+        await self.queue.put(None)  # Send None to signal end of data
+
+    async def __aenter__(self):
+        """Enter context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """Exit context manager and close the connection."""
+        await self.close()

--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -1,0 +1,107 @@
+import asyncio
+import aiohttp
+import logging
+import sys
+
+class TrickleSubscriber:
+    def __init__(self, url: str):
+        self.base_url = url
+        self.idx = -1  # Start with -1 for 'latest' index
+        self.pending_get = None  # Pre-initialized GET request
+        self.lock = asyncio.Lock()  # Lock to manage concurrent access
+        self.session = aiohttp.ClientSession()
+        self.errored = False
+
+    async def get_index(self, resp):
+        """Extract the index from the response headers."""
+        if resp is None:
+            return -1
+        idx_str = resp.headers.get("Lp-Trickle-Idx")
+        try:
+            idx = int(idx_str)
+        except (TypeError, ValueError):
+            return -1
+        return idx
+
+    async def preconnect(self):
+        """Preconnect to the server by making a GET request to fetch the next segment."""
+        url = f"{self.base_url}/{self.idx}"
+        logging.info(f"Trickle sub Preconnecting to URL: {url}")
+        try:
+
+            resp = await self.session.get(url, headers={'Connection':'close'})
+            if resp.status != 200:
+                body = await resp.text()
+                resp.release()
+                logging.error(f"Trickle sub Failed GET segment, status code: {resp.status}, msg: {body}")
+                self.errored = True
+                return None
+
+            # Return the response for later processing
+            return resp
+        except aiohttp.ClientError as e:
+            logging.error(f"Trickle sub Failed to complete GET for next segment: {e}")
+            self.errored = True
+            return None
+
+    async def next(self):
+        """Retrieve data from the current segment and set up the next segment concurrently."""
+        async with self.lock:
+
+            if self.errored:
+                logging.info("Trickle subscription closed or errored")
+                return None
+
+            # If we don't have a pending GET request, preconnect
+            if self.pending_get is None:
+                logging.info("Trickle sub No pending connection, preconnecting...")
+                self.pending_get = await self.preconnect()
+
+            # Extract the current connection to use for reading
+            conn = self.pending_get
+            self.pending_get = None
+
+            # Extract and set the next index from the response headers
+            idx = await self.get_index(conn)
+            if idx != -1:
+                self.idx = idx + 1
+
+            # Set up the next connection in the background
+            asyncio.create_task(self._preconnect_next_segment())
+
+        return Segment(conn)
+
+    async def _preconnect_next_segment(self):
+        """Preconnect to the next segment in the background."""
+        logging.info(f"Trickle sub setting up next connection for index {self.idx}")
+        async with self.lock:
+            if self.pending_get is not None:
+                return
+            next_conn = await self.preconnect()
+            if next_conn:
+                self.pending_get = next_conn
+                next_idx = await self.get_index(next_conn)
+                if next_idx != -1:
+                    self.idx = next_idx + 1
+
+class Segment:
+    def __init__(self, response):
+        self.response = response
+
+    async def read(self, chunk_size=32 * 1024):
+        """Read the next chunk of the segment."""
+        if not self.response:
+            await self.close()
+            return None
+        chunk = await self.response.content.read(chunk_size)
+        if not chunk:
+            await self.close()
+        return chunk
+
+    async def close(self):
+        """Ensure the response is properly closed when done."""
+        if self.response is None:
+            return
+        if not self.response.closed:
+            await self.response.release()
+            await self.response.close()

--- a/runner/docker/Dockerfile.live-multimedia
+++ b/runner/docker/Dockerfile.live-multimedia
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE}
 # Install necessary packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf automake build-essential cmake git-core libtool pkg-config wget \
-    nasm yasm zlib1g-dev libpng-dev && \
+    nasm yasm zlib1g-dev libpng-dev libx264-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Set up environment variables
@@ -34,6 +34,8 @@ RUN cd ffmpeg && \
                 --enable-nvenc \
                 --enable-nvdec \
                 --enable-static \
+                --enable-gpl \
+                --enable-libx264 \
                 --disable-shared \
                 --disable-debug \
                 --disable-doc && \

--- a/runner/run-lv2v.sh
+++ b/runner/run-lv2v.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -ex
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <input_room> <output_room>"
+    exit 1
+fi
+
+INPUT_ROOM=$1
+OUTPUT_ROOM=$2
+
+docker build -t livepeer/ai-runner:live-apps -f docker/Dockerfile.live-apps .
+docker run -it --rm --name live-video-to-video \
+  -e PIPELINE=live-video-to-video \
+  -e MODEL_ID=streamkohaku \
+  --gpus all \
+  -p 9000:8000 \
+  -v ./models:/models \
+  livepeer/ai-runner:live-apps 2>&1 | tee ./run-lv2v.log &
+DOCKER_PID=$!
+
+# make sure to kill the container when the script exits
+trap 'docker rm -f live-video-to-video' EXIT
+
+set +x
+
+echo "Waiting for server to start..."
+while ! grep -aq "Uvicorn running" ./run-lv2v.log; do
+  sleep 1
+done
+sleep 2
+echo "Starting pipeline from ${INPUT_ROOM} to ${OUTPUT_ROOM}..."
+
+set -x
+
+curl -vvv http://localhost:9000/live-video-to-video/ \
+  -H 'Content-Type: application/json' \
+  -d "{\"publish_url\":\"https://wwgcyxykwg9dys.transfix.ai/trickle/${OUTPUT_ROOM}\",\"subscribe_url\":\"https://wwgcyxykwg9dys.transfix.ai/trickle/${INPUT_ROOM}\"}"
+
+# let docker container take over
+wait $DOCKER_PID


### PR DESCRIPTION
Logging is still rough as I'm ironing out issues around tear-down, but wanted to put this out

Should be testable with 

```
 curl -vvv http://localhost:9000/live-video-to-video/ -H 'Content-Type: application/json' -d '{"subscribe_url":"http://trickle-server/input-stream","publish_url":"http://trickle-server/output-stream"}'
```