### PR TITLE
Fix logging in live subprocess.

### DIFF
--- a/runner/app/cfg/uvicorn_logging_config.json
+++ b/runner/app/cfg/uvicorn_logging_config.json
@@ -21,7 +21,7 @@
         "access": {
             "formatter": "access",
             "class": "logging.StreamHandler",
-            "stream": "ext://sys.stdout"
+            "stream": "ext://sys.stderr"
         }
     },
     "loggers": {


### PR DESCRIPTION
We need to read the stdout/stderr pipe from the subprocess (and if we don't it will eventually block)

Then change to uvicorn to log stderr instead of stdout, I have no idea what this actually does does but this is the only way to get `logger.info` to log in the subprocess - otherwise we only see lines from `logger.error`

(both are necessary)