### PR TITLE
Add SD3.5

### DIFF
--- a/runner/app/pipelines/text_to_image.py
+++ b/runner/app/pipelines/text_to_image.py
@@ -35,7 +35,7 @@ class ModelName(Enum):
     """Enumeration mapping model names to their corresponding IDs."""
 
     SDXL_LIGHTNING = "ByteDance/SDXL-Lightning"
-    SD3_MEDIUM = "stabilityai/stable-diffusion-3-medium-diffusers"
+    SD3 = "stabilityai/stable-diffusion-3"
     REALISTIC_VISION_V6 = "SG161222/Realistic_Vision_V6.0_B1_noVAE"
     FLUX_1_SCHNELL = "black-forest-labs/FLUX.1-schnell"
     FLUX_1_DEV = "black-forest-labs/FLUX.1-dev"
@@ -125,10 +125,11 @@ class TextToImagePipeline(Pipeline):
             self.ldm.scheduler = EulerDiscreteScheduler.from_config(
                 self.ldm.scheduler.config, timestep_spacing="trailing"
             )
-        elif ModelName.SD3_MEDIUM.value in model_id:
+        elif ModelName.SD3.value in model_id:
             self.ldm = StableDiffusion3Pipeline.from_pretrained(model_id, **kwargs).to(
                 torch_device
             )
+            kwargs["torch_dtype"] = torch.bfloat16
         elif (
             ModelName.FLUX_1_SCHNELL.value in model_id
             or ModelName.FLUX_1_DEV.value in model_id

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -61,6 +61,8 @@ function download_all_models() {
     huggingface-cli download prompthero/openjourney-v4 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download SG161222/RealVisXL_V4.0 --include "*.fp16.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download stabilityai/stable-diffusion-3-medium-diffusers --include "*.fp16*.safetensors" "*.model" "*.json" "*.txt" --cache-dir models ${TOKEN_FLAG:+"$TOKEN_FLAG"}
+    huggingface-cli download stabilityai/stable-diffusion-3.5-medium --include "transformer/*.safetensors" "*model.fp16.safetensors" "*.model" "*.json" "*.txt" --cache-dir models ${TOKEN_FLAG:+"$TOKEN_FLAG"}
+    huggingface-cli download stabilityai/stable-diffusion-3.5-large --include "transformer/*.safetensors" "*model.fp16.safetensors" "*.model" "*.json" "*.txt" --cache-dir models ${TOKEN_FLAG:+"$TOKEN_FLAG"}
     huggingface-cli download SG161222/Realistic_Vision_V6.0_B1_noVAE --include "*.fp16.safetensors" "*.json" "*.txt" "*.bin" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download black-forest-labs/FLUX.1-schnell --include "*.safetensors" "*.json" "*.txt" "*.model" --exclude ".onnx" ".onnx_data" --cache-dir models
 

--- a/runner/requirements.txt
+++ b/runner/requirements.txt
@@ -1,4 +1,4 @@
-diffusers==0.30.0
+diffusers==0.31.0
 accelerate==0.30.1
 transformers==4.43.3
 fastapi==0.111.0


### PR DESCRIPTION
Add SD3.5 to text-to-image:
- updated the SD3 by updating the ModelName for SD3 to be a substring that applies to SD3 and SD3.5. Diffusers StableDiffusion3Pipeline applies to both models.
- Stepped `diffusers` up to 0.31.0 to enable SD3.5 to work
- Added SD3.5 download lines to dl_checkpoints.sh

Model Cards
https://huggingface.co/stabilityai/stable-diffusion-3.5-large
https://huggingface.co/stabilityai/stable-diffusion-3.5-medium
