### PR TITLE
(lv2v) remove unsupported parameters

### DIFF
--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -33,8 +33,6 @@ class LiveVideoToVideoPipeline(Pipeline):
             if not self.process:
                 self.start_process(
                     pipeline=self.model_id,  # we use the model_id as the pipeline name for now
-                    input_address="tcp://localhost:5555",
-                    output_address="tcp://localhost:5556",
                     http_port=8888,
                     subscribe_url=kwargs["subscribe_url"],
                     publish_url=kwargs["publish_url"],


### PR DESCRIPTION
This change fixes an issue calling infer.py with unsupported parameters:
```
usage: infer.py [-h] [--http-port HTTP_PORT] [--pipeline PIPELINE]
                [--initial-params INITIAL_PARAMS]
                [--stream-protocol {trickle,zeromq}] --subscribe-url
                SUBSCRIBE_URL --publish-url PUBLISH_URL [-v]
infer.py: error: unrecognized arguments: --input-address tcp://localhost:5555 --output-address tcp://localhost:5556
```
