### PR TITLE
live/trickle: Updates for go-livepeer

### DIFF
--- a/runner/app/live/trickle/jpeg_parser.py
+++ b/runner/app/live/trickle/jpeg_parser.py
@@ -16,7 +16,6 @@ class JPEGStreamParser:
         return self
 
     def __exit__(self, exec_type, exec_val, exec_tb):
-        logging.info("JOSH closing jpeg parser via exit")
         self.close()
 
     def close(self):

--- a/runner/app/live/trickle/media.py
+++ b/runner/app/live/trickle/media.py
@@ -12,7 +12,6 @@ from . import segmenter
 
 # target framerate
 FRAMERATE=segmenter.FRAMERATE
-GOP_SECS=segmenter.GOP_SECS
 
 # TODO make this better configurable
 GPU=segmenter.GPU
@@ -32,7 +31,7 @@ async def run_subscribe(subscribe_url: str, image_callback):
 
 async def subscribe(subscribe_url, out_pipe):
     subscriber = TrickleSubscriber(url=subscribe_url)
-    logging.info(f"JOSH - launching subscribe loop for {subscribe_url}")
+    logging.info(f"launching subscribe loop for {subscribe_url}")
     while True:
         segment = None
         try:

--- a/runner/app/live/trickle/segmenter.py
+++ b/runner/app/live/trickle/segmenter.py
@@ -41,12 +41,12 @@ def ffmpeg_cmd(out_pattern):
         cmd = [
         'ffmpeg',
 	    '-loglevel', 'warning',
+        '-use_wallclock_as_timestamps', '1',
         '-f', 'image2pipe',
-        '-framerate', f"{FRAMERATE}",
         '-i', 'pipe:0', # stdin
         '-c:v', 'h264_nvenc',
         '-bf', '0', # disable bframes for webrtc
-        '-g', f'{GOP_SECS*FRAMERATE}',
+        '-force_key_frames', f'expr:gte(t,n_forced*{GOP_SECS})',
         '-preset', 'p1',
         '-tune', 'ull',
         '-f', 'segment',
@@ -56,19 +56,19 @@ def ffmpeg_cmd(out_pattern):
         cmd = [
         'ffmpeg',
 	    '-loglevel', 'warning',
+        '-use_wallclock_as_timestamps', '1',
         '-f', 'image2pipe',
-        '-framerate', f"{FRAMERATE}",
         '-i', 'pipe:0', # stdin
         '-c:v', 'libx264',
         '-bf', '0', # disable bframes for webrtc
-        '-g', f'{GOP_SECS*FRAMERATE}',
+        '-force_key_frames', f'expr:gte(t,n_forced*{GOP_SECS})',
         '-preset', 'superfast',
         '-tune', 'zerolatency',
         '-f', 'segment',
         out_pattern
         ]
 
-    logging.info(f"JOSH - ffmpeg (output) {cmd}")
+    logging.info(f"ffmpeg (output) {cmd}")
     return cmd
 
 

--- a/runner/app/live/trickle/trickle_publisher.py
+++ b/runner/app/live/trickle/trickle_publisher.py
@@ -10,7 +10,7 @@ class TricklePublisher:
         self.idx = 0  # Start index for POSTs
         self.next_writer = None
         self.lock = asyncio.Lock()  # Lock to manage concurrent access
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))
 
     async def __aenter__(self):
         """Enter context manager."""

--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -47,11 +47,11 @@ class TrickleSubscriber:
                 self.pending_get = await self.preconnect()
 
             # Extract the current connection to use for reading
-            conn = self.pending_get
+            resp = self.pending_get
             self.pending_get = None
 
             # Extract and set the next index from the response headers
-            segment = Segment(conn)
+            segment = Segment(resp)
 
             if segment.eos():
                 return None

--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -9,19 +9,8 @@ class TrickleSubscriber:
         self.idx = -1  # Start with -1 for 'latest' index
         self.pending_get = None  # Pre-initialized GET request
         self.lock = asyncio.Lock()  # Lock to manage concurrent access
-        self.session = aiohttp.ClientSession()
+        self.session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))
         self.errored = False
-
-    async def get_index(self, resp):
-        """Extract the index from the response headers."""
-        if resp is None:
-            return -1
-        idx_str = resp.headers.get("Lp-Trickle-Idx")
-        try:
-            idx = int(idx_str)
-        except (TypeError, ValueError):
-            return -1
-        return idx
 
     async def preconnect(self):
         """Preconnect to the server by making a GET request to fetch the next segment."""
@@ -62,14 +51,19 @@ class TrickleSubscriber:
             self.pending_get = None
 
             # Extract and set the next index from the response headers
-            idx = await self.get_index(conn)
-            if idx != -1:
+            segment = Segment(conn)
+
+            if segment.eos():
+                return None
+
+            idx = segment.seq()
+            if idx >= 0:
                 self.idx = idx + 1
 
             # Set up the next connection in the background
             asyncio.create_task(self._preconnect_next_segment())
 
-        return Segment(conn)
+        return segment
 
     async def _preconnect_next_segment(self):
         """Preconnect to the next segment in the background."""
@@ -80,13 +74,22 @@ class TrickleSubscriber:
             next_conn = await self.preconnect()
             if next_conn:
                 self.pending_get = next_conn
-                next_idx = await self.get_index(next_conn)
-                if next_idx != -1:
-                    self.idx = next_idx + 1
 
 class Segment:
     def __init__(self, response):
         self.response = response
+
+    def seq(self):
+        """Extract the sequence number from the response headers."""
+        seq_str = self.response.headers.get('Lp-Trickle-Seq')
+        try:
+            seq = int(seq_str)
+        except (TypeError, ValueError):
+            return -1
+        return seq
+
+    def eos(self):
+        return self.response.headers.get('Lp-Trickle-Closed') != None
 
     async def read(self, chunk_size=32 * 1024):
         """Read the next chunk of the segment."""


### PR DESCRIPTION
Use `Lp-Trickle-Seq` as the header for sequence numbering

Better end-of-stream handling

Ignore SSL certificates since orchestrators generate them at runtime

Don't assume a fixed frame rate for output video; use what we have

Logging cleanup