### PR TITLE
runner/live: Make sure to resize images outside of infer process

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -121,7 +121,15 @@ class PipelineStreamer(ABC):
             async for frame in self.ingress_loop(done):
                 if done.is_set() or not self.process:
                     return
-                logging.debug(f"Sending input frame. width: {frame.width}, height: {frame.height}")
+
+                # crop the max square from the center of the image and scale to 512x512
+                # most models expect this size especially when using tensorrt
+                width, height = frame.size
+                square_size = min(width, height)
+                frame = frame.crop((width // 2 - square_size // 2, height // 2 - square_size // 2, width // 2 + square_size // 2, height // 2 + square_size // 2))
+                frame = frame.resize((512, 512))
+
+                logging.debug(f"Sending input frame. Scaled from {width}x{height} to 512x512")
                 self.process.send_input(frame)
 
                 # Increment frame count and measure FPS

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -124,10 +124,12 @@ class PipelineStreamer(ABC):
 
                 # crop the max square from the center of the image and scale to 512x512
                 # most models expect this size especially when using tensorrt
-                width, height = frame.size
-                square_size = min(width, height)
-                frame = frame.crop((width // 2 - square_size // 2, height // 2 - square_size // 2, width // 2 + square_size // 2, height // 2 + square_size // 2))
-                frame = frame.resize((512, 512))
+                if frame.width != frame.height:
+                    width, height = frame.size
+                    square_size = min(width, height)
+                    frame = frame.crop((width // 2 - square_size // 2, height // 2 - square_size // 2, width // 2 + square_size // 2, height // 2 + square_size // 2))
+                if frame.size != (512, 512):
+                    frame = frame.resize((512, 512))
 
                 logging.debug(f"Sending input frame. Scaled from {width}x{height} to 512x512")
                 self.process.send_input(frame)


### PR DESCRIPTION
On the LiveKit PoC we resized the images on the agent code, and were missing that part from this infer.py piece. This is probably one reason for the inference to be lower on the ai-worker as the resize still happened, but it happened on the same process as we run the model so it was competing for the same Python GIL (and resizing on CPU might be some relevant time).