### PR TITLE
runner/docker: Fix streamdiffusion deps installation

### DIFF
--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -16,12 +16,12 @@ RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 
 RUN pip install --no-cache-dir \
     torch==2.1.0 \
     torchvision==0.16.0 \
-    diffusers==0.30.0 \
-    
     xformers \
-    protobuf==5.27.2 \
     --index-url https://download.pytorch.org/whl/cu121
-RUN pip install huggingface-hub==0.23.2
+RUN pip install --no-cache-dir \
+    huggingface-hub==0.23.2 \
+    diffusers==0.30.0 \
+    protobuf==5.27.2
 
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
 RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]


### PR DESCRIPTION
The diffusers and protobuf should come from the regular pypy repo, not the pytorch index.