### PR TITLE
docker: ComfyUI model downloading/caching

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -77,7 +77,11 @@ function download_all_models() {
     # Custom pipeline models.
     huggingface-cli download facebook/sam2-hiera-large --include "*.pt" "*.yaml" --cache-dir models
 
-    # Download live-video-to-video models.
+    download_live_models
+}
+
+# Download models only for the live-video-to-video pipeline.
+function download_live_models() {
     huggingface-cli download KBlueLeaf/kohaku-v2.1 --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download stabilityai/sd-turbo --include "*.safetensors" "*.json" "*.txt" --exclude ".onnx" ".onnx_data" --cache-dir models
     huggingface-cli download warmshao/FasterLivePortrait --local-dir models/FasterLivePortrait--checkpoints
@@ -85,7 +89,7 @@ function download_all_models() {
 }
 
 function build_tensorrt_models() {
-    download_all_models
+    download_live_models
 
     printf "\nBuilding TensorRT models...\n"
 
@@ -158,6 +162,10 @@ do
             MODE="restricted"
             shift
         ;;
+        --live)
+            MODE="live"
+            shift
+        ;;
         --tensorrt)
             MODE="tensorrt"
             shift
@@ -188,6 +196,8 @@ if [ "$MODE" = "beta" ]; then
     download_beta_models
 elif [ "$MODE" = "restricted" ]; then
     download_restricted_models
+elif [ "$MODE" = "live" ]; then
+    download_live_models
 elif [ "$MODE" = "tensorrt" ]; then
     build_tensorrt_models
 else

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -37,5 +37,5 @@ RUN git clone https://github.com/yondonfu/comfystream.git && \
 
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/comfyui"
-RUN ln -s /comfyui/models /models/ComfyUI--models
+RUN mkdir -p /models && ln -s /comfyui/models /models/ComfyUI--models
 # TODO: Consider linking the custom nodes directory as well and set those up in the host, similar to the models directory

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -22,7 +22,7 @@ RUN cd /comfyui/custom_nodes && \
     pip install -r requirements.txt
 
 # Upgrade TensorRT to 10.6.0
-RUN pip uninstall -y tensorrt && \ 
+RUN pip uninstall -y tensorrt && \
     pip install tensorrt==10.6.0
 
 RUN pip install torch==2.5.1 torchvision torchaudio tqdm
@@ -37,4 +37,5 @@ RUN git clone https://github.com/yondonfu/comfystream.git && \
 
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/comfyui"
-RUN ln -s /comfyui/models /models
+RUN ln -s /comfyui/models /models/ComfyUI--models
+# TODO: Consider linking the custom nodes directory as well and set those up in the host, similar to the models directory

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -37,5 +37,5 @@ RUN git clone https://github.com/yondonfu/comfystream.git && \
 
 # Set up ComfyUI workspace
 ENV COMFY_UI_WORKSPACE="/comfyui"
-RUN mkdir -p /models && ln -s /comfyui/models /models/ComfyUI--models
+RUN ln -s /models/ComfyUI--models /comfyui/models
 # TODO: Consider linking the custom nodes directory as well and set those up in the host, similar to the models directory


### PR DESCRIPTION
This is to fix the ComfyUI docker container to use a separate directory 
in the `models` dir, and also allow downloading/compiling them using the
existing dl_checkpoints script.

Also:
- created a `--live` mode on the download script to only download the live-video-to-video models
- made the `--tensorrt` mode only require those models to be downloaded as well, skipping a bunch of other models