### PR TITLE
worker,runner: Fix lifecycle management of realtime containers

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -104,7 +104,7 @@ class PipelineStreamer(ABC):
 
             if self.input_timeout > 0 and time_since_last_input > self.input_timeout:
                 logging.info(f"Input stream stopped for {time_since_last_input} seconds. Shutting down...")
-                await self.stop()
+                await asyncio.create_task(self.stop())
                 return
 
             gone_stale = (

--- a/runner/app/pipelines/live_video_to_video.py
+++ b/runner/app/pipelines/live_video_to_video.py
@@ -91,7 +91,7 @@ class LiveVideoToVideoPipeline(Pipeline):
                 else:
                     # If process exited cleanly (return code 0) and exit the main process
                     logger.info("infer.py process exited cleanly, shutting down...")
-                    sys.exit(0)
+                    os._exit(0)
                 break
 
             logger.info("infer.py process is running...")

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -372,7 +372,10 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer, borrowCtx context.Co
 			ctx, cancel := context.WithTimeout(context.Background(), containerWatchInterval)
 			container, err := m.dockerClient.ContainerInspect(ctx, rc.ID)
 			cancel()
-			if err != nil {
+
+			if docker.IsErrNotFound(err) {
+				// skip to destroy below to update internal state
+			} else if err != nil {
 				slog.Error("Error inspecting container",
 					slog.String("container", rc.Name),
 					slog.String("error", err.Error()))
@@ -414,20 +417,35 @@ func dockerContainerName(pipeline string, modelID string, suffix ...string) stri
 
 func dockerRemoveContainer(client *docker.Client, containerID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), containerRemoveTimeout)
+	defer cancel()
+
 	err := client.ContainerStop(ctx, containerID, container.StopOptions{})
-	cancel()
 	// Ignore "not found" or "already stopped" errors
 	if err != nil && !docker.IsErrNotFound(err) && !errdefs.IsNotModified(err) {
 		return err
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), containerRemoveTimeout)
 	err = client.ContainerRemove(ctx, containerID, container.RemoveOptions{})
-	cancel()
-	if err != nil && !docker.IsErrNotFound(err) {
+	if err == nil || docker.IsErrNotFound(err) {
+		return nil
+	} else if err != nil && !strings.Contains(err.Error(), "is already in progress") {
 		return err
 	}
-	return nil
+	// The container is being removed asynchronously, wait until it is actually gone
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for container removal to complete")
+		case <-ticker.C:
+			_, err := client.ContainerInspect(ctx, containerID)
+			if docker.IsErrNotFound(err) {
+				return nil
+			}
+		}
+	}
 }
 
 func dockerWaitUntilRunning(ctx context.Context, client *docker.Client, containerID string, pollingInterval time.Duration) error {


### PR DESCRIPTION
The shutdown logic needed some clean-up for the infer.py process, both internally and externally:
- internally, we needed to cleanup some multiprocessing resources so the main process is allowed to exit
- externally, we needed to use os._exit instead of sys.exit to exit the main app process