### PR TITLE
Support for JSON string in defaultImage field for overriding pipeline specific images in the mappings 

### DIFF
--- a/worker/docker.go
+++ b/worker/docker.go
@@ -104,6 +104,14 @@ type DockerManager struct {
 }
 
 func overridePipelineImages(defaultImage string) error {
+	// overridePipelineImages function parses a JSON string containing pipeline-to-image mappings and overrides the default mappings if valid. 
+	// It updates the `pipelineToImage` and `livePipelineToImage` maps with custom images.
+	// Parameters:
+	// - defaultImage: A string that can either be containerImage name or a JSON string with overrides for pipeline-to-image mappings.
+	//
+	// Returns:
+	// - error: An error if the JSON parsing fails or if the mapping is not found in existing maps else `nil`.
+
 	// First check if the defaultImage is a valid JSON string
 	var pipelineOverrides map[string]string
 	if strings.HasPrefix(defaultImage, "{") && strings.HasSuffix(defaultImage, "}") {

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -56,7 +56,7 @@ var containerHostPorts = map[string]string{
 	"live-video-to-video": "8900",
 }
 
-// Mapping for per pipeline container images.
+// Default pipeline container image mapping to use if no overrides are provided.
 var defaultBaseImage = "livepeer/ai-runner:latest"
 var pipelineToImage = map[string]string{
 	"segment-anything-2": "livepeer/ai-runner:segment-anything-2",
@@ -97,10 +97,9 @@ var _ DockerClient = (*docker.Client)(nil)
 var dockerWaitUntilRunningFunc = dockerWaitUntilRunning
 
 type DockerManager struct {
-	defaultImage string
-	gpus         []string
-	modelDir     string
-	overrides    ImageOverrides
+	gpus      []string
+	modelDir  string
+	overrides ImageOverrides
 
 	dockerClient DockerClient
 	// gpu ID => container name

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -103,15 +103,14 @@ type DockerManager struct {
 	mu         *sync.Mutex
 }
 
+// overridePipelineImages function parses a JSON string containing pipeline-to-image mappings and overrides the default mappings if valid. 
+// It updates the `pipelineToImage` and `livePipelineToImage` maps with custom images.
+// Parameters:
+// - defaultImage: A string that can either be containerImage name or a JSON string with overrides for pipeline-to-image mappings.
+//
+// Returns:
+// - error: An error if the JSON parsing fails or if the mapping is not found in existing maps else `nil`.
 func overridePipelineImages(defaultImage string) error {
-	// overridePipelineImages function parses a JSON string containing pipeline-to-image mappings and overrides the default mappings if valid. 
-	// It updates the `pipelineToImage` and `livePipelineToImage` maps with custom images.
-	// Parameters:
-	// - defaultImage: A string that can either be containerImage name or a JSON string with overrides for pipeline-to-image mappings.
-	//
-	// Returns:
-	// - error: An error if the JSON parsing fails or if the mapping is not found in existing maps else `nil`.
-
 	// First check if the defaultImage is a valid JSON string
 	var pipelineOverrides map[string]string
 	if strings.HasPrefix(defaultImage, "{") || strings.HasSuffix(defaultImage, "}") {

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -114,10 +114,12 @@ func overridePipelineImages(defaultImage string) error {
 
 	// First check if the defaultImage is a valid JSON string
 	var pipelineOverrides map[string]string
-	if strings.HasPrefix(defaultImage, "{") && strings.HasSuffix(defaultImage, "}") {
+	if strings.HasPrefix(defaultImage, "{") || strings.HasSuffix(defaultImage, "}") {
 		// Parse the JSON string for custom pipeline images override
-		if err := json.Unmarshal([]byte(defaultImage), &pipelineOverrides); err != nil {
-			return fmt.Errorf("failed to parse pipeline overrides JSON: %w", err)
+		err := json.Unmarshal([]byte(defaultImage), &pipelineOverrides)
+		if err != nil {
+			slog.Error("Malformed JSON in pipeline override", "error", err, "json", defaultImage)
+			return err
 		}
 
 		// Override the pipelineToImage and livePipelineToImage mappings

--- a/worker/docker_test.go
+++ b/worker/docker_test.go
@@ -1032,6 +1032,13 @@ func TestDockerManager_overridePipelineImages(t *testing.T) {
 			pipeline:    "segment-anything-2",
 			expectError: true,
 		},
+		{
+			name:          "RegularStringInput",
+			inputJSON:     "",
+			pipeline:      "image-to-video",
+			expectedImage: "default-image",
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/worker/docker_test.go
+++ b/worker/docker_test.go
@@ -1015,7 +1015,7 @@ func TestDockerManager_overridePipelineImages(t *testing.T) {
 		{
 			name:          "NoOverrideFallback",
 			inputJSON:     `{"segment-anything-2": "custom-image:1.0"}`,
-			pipeline:      "video-to-video",
+			pipeline:      "streamdiffusion",
 			expectedImage: "default-image",
 			expectError:   false,
 		},
@@ -1023,12 +1023,12 @@ func TestDockerManager_overridePipelineImages(t *testing.T) {
 			name:        "EmptyJSON",
 			inputJSON:   `{}`,
 			pipeline:    "segment-anything-2",
-			expectedImage: "default-image",
+			expectedImage: "custom-image:1.0",
 			expectError:   false,
 		},
 		{
 			name:        "MalformedJSON",
-			inputJSON:   `{"segment-anything-2": "custom-image:1.0`,
+			inputJSON:   `{"segment-anything-2": "custom-image:1.0"`,
 			pipeline:    "segment-anything-2",
 			expectError: true,
 		},

--- a/worker/docker_test.go
+++ b/worker/docker_test.go
@@ -986,3 +986,68 @@ func TestDockerWaitUntilRunning(t *testing.T) {
 		mockDockerClient.AssertExpectations(t)
 	})
 }
+
+func TestDockerManager_overridePipelineImages(t *testing.T) {
+	mockDockerClient := new(MockDockerClient)
+	dockerManager := createDockerManager(mockDockerClient)
+
+	tests := []struct {
+		name          string
+		inputJSON     string
+		pipeline      string
+		expectedImage string
+		expectError   bool
+	}{
+		{
+			name:          "ValidOverride",
+			inputJSON:     `{"segment-anything-2": "custom-image:1.0"}`,
+			pipeline:      "segment-anything-2",
+			expectedImage: "custom-image:1.0",
+			expectError:   false,
+		},
+		{
+			name:          "MultipleOverrides",
+			inputJSON:     `{"segment-anything-2": "custom-image:1.0", "text-to-speech": "speech-image:2.0"}`,
+			pipeline:      "text-to-speech",
+			expectedImage: "speech-image:2.0",
+			expectError:   false,
+		},
+		{
+			name:          "NoOverrideFallback",
+			inputJSON:     `{"segment-anything-2": "custom-image:1.0"}`,
+			pipeline:      "video-to-video",
+			expectedImage: "default-image",
+			expectError:   false,
+		},
+		{
+			name:        "EmptyJSON",
+			inputJSON:   `{}`,
+			pipeline:    "segment-anything-2",
+			expectedImage: "default-image",
+			expectError:   false,
+		},
+		{
+			name:        "MalformedJSON",
+			inputJSON:   `{"segment-anything-2": "custom-image:1.0`,
+			pipeline:    "segment-anything-2",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call overridePipelineImages function with the mock data.
+			err := overridePipelineImages(tt.inputJSON)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				
+				// Verify the expected image.
+				image, _ := dockerManager.getContainerImageName(tt.pipeline, "")
+				require.Equal(t, tt.expectedImage, image)
+			}
+		})
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -51,13 +51,13 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(defaultImage string, gpus []string, modelDir string) (*Worker, error) {
+func NewWorker(imageOverrides string, gpus []string, modelDir string) (*Worker, error) {
 	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}
 
-	manager, err := NewDockerManager(defaultImage, gpus, modelDir, dockerClient)
+	manager, err := NewDockerManager(imageOverrides, gpus, modelDir, dockerClient)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -51,7 +51,7 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(imageOverrides string, gpus []string, modelDir string) (*Worker, error) {
+func NewWorker(imageOverrides ImageOverrides, gpus []string, modelDir string) (*Worker, error) {
 	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Towards closing ['livepeer/bounties/#69](https://github.com/livepeer/bounties/issues/69)

This PR adds support for processing JSON string in `defaultImage`and specifies pipeline-specific images as key-value pairs with their mappings being updated to override `containerImage`.

`go-livepeer` PR which it supports is [#3284](https://github.com/livepeer/go-livepeer/pull/3284)

cc @rickstaa 