### PR TITLE
fix: managed containers return after inference completed

### DIFF
--- a/worker/docker.go
+++ b/worker/docker.go
@@ -174,7 +174,6 @@ func (m *DockerManager) Borrow(ctx context.Context, pipeline, modelID string) (*
 
 	for _, runner := range m.containers {
 		if runner.Pipeline == pipeline && runner.ModelID == modelID {
-			delete(m.containers, runner.Name)
 			rc = runner
 			break
 		}

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -169,24 +169,29 @@ func (m *DockerManager) Stop(ctx context.Context) error {
 func (m *DockerManager) Borrow(ctx context.Context, pipeline, modelID string) (*RunnerContainer, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	var rc *RunnerContainer
+	var err error
 
 	for _, runner := range m.containers {
 		if runner.Pipeline == pipeline && runner.ModelID == modelID {
 			delete(m.containers, runner.Name)
-			return runner, nil
+			rc = runner
+			break
 		}
 	}
 
 	// The container does not exist so try to create it
-	var err error
-	// TODO: Optimization flags for dynamically loaded (borrowed) containers are not currently supported due to startup delays.
-	rc, err := m.createContainer(ctx, pipeline, modelID, false, map[string]EnvValue{})
-	if err != nil {
-		return nil, err
+	if rc == nil {
+		// TODO: Optimization flags for dynamically loaded (borrowed) containers are not currently supported due to startup delays.
+		rc, err = m.createContainer(ctx, pipeline, modelID, false, map[string]EnvValue{})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Remove container so it is unavailable until Return() is called
 	delete(m.containers, rc.Name)
+	// watch container to return when request completed
 	go m.watchContainer(rc, ctx)
 
 	return rc, nil


### PR DESCRIPTION
@victorges @rickstaa Please review this PR to fix container return for managed containers inference.  

This was found from a report from an Orchestrator getting `insufficient capacity` error when using managed containers after the first request was completed.

I confirmed this was happening on my test machine and also confirmed it was happening on `ImageToImage` pipeline.

This fix delays the `return` in the `Borrow` function until after the `go m.watchContainer(rc, ctx)` is started.