### PR TITLE
Add error handling to control message handler task

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -74,9 +74,20 @@ async def start_control_subscriber(handler: PipelineStreamer, control_url: str):
         segment = await subscriber.next()
         if segment.eos():
             return
-        params = await segment.read()
-        logging.info("Received control message, updating model with params: %s", params)
-        handler.update_params(**json.loads(params))
+
+        try:
+            params = await segment.read()
+            logging.info("Received control message, updating model with params: %s", params)
+            data = json.loads(params)
+        except Exception as e:
+            logging.error(f"Error parsing control message: {e}")
+            continue
+        
+        try:        
+            handler.update_params(data)
+        except Exception as e:
+            logging.error(f"Error updating model with control message: {e}")
+            continue
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Infer process to run the AI pipeline")


### PR DESCRIPTION
This change adds error handling to the `start_control_subscriber` task so that any invalid request or error in processing model parameter updates will not cause the control subscribe task to fail. 

Previously if an invalid request is sent, the control subscribe task will silently stop and will not process further requests.