### PR TITLE
Add nvidia-ml-py to requirements

### DIFF
--- a/runner/requirements-liveportrait.txt
+++ b/runner/requirements-liveportrait.txt
@@ -10,3 +10,4 @@ pycuda==2024.1.2
 scikit-image==0.24.0
 torchgeometry==0.1.2
 torchvision==0.19.1
+nvidia-ml-py==12.560.30

--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -22,3 +22,4 @@ PyGObject==3.50.0
 onnxruntime==1.19.2
 watchdog==5.0.2
 aiohttp==3.10.9
+nvidia-ml-py==12.560.30


### PR DESCRIPTION
This change adds `nvidia-ml-py` to `requirements.live-ai.txt` and `requirements-liveportrait.txt` to resolve a missing import error in live pipelines.

The package was previously added to `requirements.txt`, however the live pipelines do not use this requirements file leading to a missing import error at runtime.