### PR TITLE
feat: add flash_attention_2 to audio_to_text pipeline's attn_implementation

### DIFF
--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -32,6 +32,7 @@ jobs:
         dockerfile:
           - docker/Dockerfile.segment_anything_2
           - docker/Dockerfile.text_to_speech
+          - docker/Dockerfile.audio_to_text
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import List
 
 import torch
-import warnings
 from fastapi import File, UploadFile
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline
 
@@ -74,7 +73,7 @@ class AudioToTextPipeline(Pipeline):
         if (major, minor) >= (8, 0):
             attn_implementation = "flash_attention_2"
         else:
-            warnings.warn(f"GPU {device.name} (Compute Capability {major}.{minor}) is not compatible with FlashAttention so, scaled_dot_product_attention is being used instead")
+            logger.warning(f"GPU {device.name} (Compute Capability {major}.{minor}) is not compatible with FlashAttention, so scaled_dot_product_attention is being used instead.")
             attn_implementation = "sdpa"
 
         # Get model specific configuration parameters.

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -93,9 +93,12 @@ class AudioToTextPipeline(Pipeline):
             low_cpu_mem_usage=True,
             use_safetensors=True,
             cache_dir=get_model_dir(),
-            attn_implementation=attn_implementation,
             **kwargs,
-        ).to(torch_device)
+        ).to('cpu')
+
+        # Move the model to the GPU
+        model = model.to(torch_device)
+        model.config.attn_implementation = attn_implementation
 
         processor = AutoProcessor.from_pretrained(model_id, cache_dir=get_model_dir())
 

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -100,7 +100,7 @@ class AudioToTextPipeline(Pipeline):
             use_safetensors=True,
             cache_dir=get_model_dir(),
             attn_implementation=attn_implementation,
-            device_map={"": torch_device},
+            device_map="auto",
             **kwargs,
         )
 
@@ -112,7 +112,7 @@ class AudioToTextPipeline(Pipeline):
             tokenizer=processor.tokenizer,
             feature_extractor=processor.feature_extractor,
             max_new_tokens=128,
-            device_map={"", torch_device},
+            device_map="auto",
             **kwargs,
         )
 

--- a/runner/app/pipelines/audio_to_text.py
+++ b/runner/app/pipelines/audio_to_text.py
@@ -93,7 +93,6 @@ class AudioToTextPipeline(Pipeline):
             low_cpu_mem_usage=True,
             use_safetensors=True,
             cache_dir=get_model_dir(),
-            torch_dtype="auto",
             attn_implementation=attn_implementation,
             **kwargs,
         ).to(torch_device)

--- a/runner/docker/Dockerfile.audio_to_text
+++ b/runner/docker/Dockerfile.audio_to_text
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE=livepeer/ai-runner:base
+FROM ${BASE_IMAGE}
+
+# Install CUDA Toolkit to enable flash attention.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends cuda-toolkit-12-1 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    transformers==4.43.3 \
+    peft \
+    deepcache \
+    flash_attn
+
+# Override base working directory to ensure the correct working directory.
+WORKDIR /app
+
+# Copy app directory to avoid rebuilding the base image during development.
+COPY app/ /app/app
+
+CMD ["uvicorn", "app.main:app", "--log-config", "app/cfg/uvicorn_logging_config.json", "--host", "0.0.0.0", "--port", "8000"]

--- a/runner/docker/Dockerfile.audio_to_text
+++ b/runner/docker/Dockerfile.audio_to_text
@@ -10,7 +10,8 @@ RUN pip install --no-cache-dir \
     transformers==4.43.3 \
     peft \
     deepcache \
-    flash_attn
+    flash_attn \
+    pynvml
 
 # Override base working directory to ensure the correct working directory.
 WORKDIR /app

--- a/worker/docker.go
+++ b/worker/docker.go
@@ -56,6 +56,7 @@ var containerHostPorts = map[string]string{
 var pipelineToImage = map[string]string{
 	"segment-anything-2": "livepeer/ai-runner:segment-anything-2",
 	"text-to-speech":     "livepeer/ai-runner:text-to-speech",
+	"audio-to-text":      "livepeer/ai-runner:audio-to-text"
 }
 
 var livePipelineToImage = map[string]string{


### PR DESCRIPTION
This PR enables flash attention for `audio-to-text` pipeline. 
`runner/docker/Dockerfile.audio_to_text` can be used to build image for flash_attention_2 enabled A2T pipeline. `sdpa` attention implementation has been added in fallback condition for the GPUs that don't support flash attention. `sdpa` also improves the latency.