### PR TITLE
runner/live: Ignore keepalive messages from control subscriber

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -72,6 +72,7 @@ async def start_control_subscriber(handler: PipelineStreamer, control_url: str):
         return
     logging.info("Starting Control subscriber at %s", control_url)
     subscriber = TrickleSubscriber(url=control_url)
+    keepalive_message = {"keep": "alive"}
     while True:
         segment = await subscriber.next()
         if segment.eos():
@@ -81,6 +82,9 @@ async def start_control_subscriber(handler: PipelineStreamer, control_url: str):
             params = await segment.read()
             logging.info("Received control message, updating model with params: %s", params)
             data = json.loads(params)
+            if data == keepalive_message:
+                # Ignore periodic keepalive messages
+                continue
         except Exception as e:
             logging.error(f"Error parsing control message: {e}")
             continue


### PR DESCRIPTION
The control channel only sees sporadic messages, so the publisher will send down a keepalive periodically to prevent clients from timing out and to prevent the server from sweeping idle channels.

Needed for https://github.com/livepeer/go-livepeer/pull/3296 and https://github.com/livepeer/go-livepeer/pull/3299