### PR TITLE
(chore) fix startup with asyncio.create_task

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -37,7 +37,7 @@ async def main(http_port: int, stream_protocol: str, subscribe_url: str, publish
         runner = await start_http_server(streamer, http_port)
 
         tasks: List[asyncio.Task] = []
-        tasks.append(streamer.wait())
+        tasks.append(asyncio.create_task(streamer.wait()))
         tasks.append(asyncio.create_task(block_until_signal([signal.SIGINT, signal.SIGTERM])))
         if control_url is not None and control_url.strip() != "":
             tasks.append(asyncio.create_task(start_control_subscriber(streamer, control_url)))


### PR DESCRIPTION
This change fixes an issue with the comfyui pipelines starting inference. It uses `asyncio.create_task(streamer.wait()))` instead of `streamer.wait()`.

Tested with managed/external containers and with both python 3.10/11