### PR TITLE
change github build action to run on oxford for live-pipeline builds

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Build common live base image
     permissions:
       pull-requests: read
-    runs-on: ubuntu-20.04
+    runs-on: oxford
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1
@@ -81,7 +81,7 @@ jobs:
   build-pipeline-images:
     name: Build pipeline images
     needs: build-common-base
-    runs-on: ubuntu-20.04
+    runs-on: oxford
     permissions:
       pull-requests: read
     strategy:


### PR DESCRIPTION
docker builds are failing due to running out of space on the ubuntu24-04 runner, switching to oxford to un-break build for PR https://github.com/livepeer/ai-worker/pull/316