### PR TITLE
ci(runner): change live pipelines docker runner

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Build common live base image
     permissions:
       pull-requests: read
-    runs-on: oxford
+    runs-on: self-hosted
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1
@@ -81,7 +81,7 @@ jobs:
   build-pipeline-images:
     name: Build pipeline images
     needs: build-common-base
-    runs-on: oxford
+    runs-on: self-hosted
     permissions:
       pull-requests: read
     strategy:


### PR DESCRIPTION
This pull request changes the `oxford` runner to use our group of self-hosted runners (see https://github.com/livepeer/ai-worker/pull/318#issuecomment-2527699647).
