### PR TITLE
ci(worker): update go version

### DIFF
--- a/.github/workflows/ai-worker-test.yaml
+++ b/.github/workflows/ai-worker-test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
 
       - name: Install dependencies
         working-directory: worker


### PR DESCRIPTION
This pull request ensures that the worker tests use the same go version as defined in the go.mod file.
