### PR TITLE
ci(worker): fix worker test ci go version error

### DIFF
--- a/.github/workflows/ai-worker-test.yaml
+++ b/.github/workflows/ai-worker-test.yaml
@@ -19,9 +19,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
+        id: go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: './go.mod'
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Install dependencies
         working-directory: worker


### PR DESCRIPTION
This pull request makes use of the `go-version-file` option and caching behavoirs of the `actions/setup-go` action so that we don't have the CI throw a go version error.
