### PR TITLE
runner/req: Add pynvml dependency

### DIFF
--- a/runner/requirements.live-ai.txt
+++ b/runner/requirements.live-ai.txt
@@ -23,3 +23,4 @@ onnxruntime==1.19.2
 watchdog==5.0.2
 aiohttp==3.10.9
 nvidia-ml-py==12.560.30
+pynvml==12.0.0


### PR DESCRIPTION
We added to the main requirements file tho we don't use that from the live runner, 
so gotta add to the live-ai requirements too. We later need to figure this out so we 
don't need to duplicate deps.