### PR TITLE
add missing comma to pipelineToImage

### DIFF
--- a/worker/docker.go
+++ b/worker/docker.go
@@ -56,7 +56,7 @@ var containerHostPorts = map[string]string{
 var pipelineToImage = map[string]string{
 	"segment-anything-2": "livepeer/ai-runner:segment-anything-2",
 	"text-to-speech":     "livepeer/ai-runner:text-to-speech",
-	"audio-to-text":      "livepeer/ai-runner:audio-to-text"
+	"audio-to-text":      "livepeer/ai-runner:audio-to-text",
 }
 
 var livePipelineToImage = map[string]string{


### PR DESCRIPTION
This change replaces a missing comma in `docker.go` that's showing as a compilation error from go-livepeer. This comma was left out in https://github.com/livepeer/ai-worker/pull/308