### PR TITLE
ci(runner): temporarily disable pipeline concurrency cancellation

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false  # TODO: enable again when LivePortrait build successfully again.
 
 jobs:
   build-common-base:


### PR DESCRIPTION
This pull request temporarily disables the `cancel-in-progress` option due to issues in the `LivePortrait` runner, which prevent us from pushing new ComfyUI containers (see )
