### PR TITLE
ci(runner): change docker driver for self-hosted runners

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false  # TODO: enable again when LivePortrait build successfully again.
 
 jobs:
   build-common-base:
@@ -55,6 +55,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -104,6 +106,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request changes the docker-driver to `docker-container` for the pipline build jobs that use `self-hosted` runners.
