### PR TITLE
ci(runner): prevent pipeline docker CI from running on mac

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Build common live base image
     permissions:
       pull-requests: read
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux]
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1
@@ -77,7 +77,7 @@ jobs:
   build-pipeline-images:
     name: Build pipeline images
     needs: build-common-base
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux]
     permissions:
       pull-requests: read
     strategy:


### PR DESCRIPTION
This pull request prevents the pipelin docker CI to run on the self-hosted mac machine since it causes docker hub authentication issues.
