### PR TITLE
ci(runner): remove cancel in progress option from pipline docker CI

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -19,7 +19,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false  # TODO: enable again when LivePortrait build successfully again.
 
 jobs:
   build-common-base:


### PR DESCRIPTION
This pull request removes the `cancel-in-progress` workflow action option since it is the desired behavoir.
