### PR TITLE
ci(runner): add amd64 runner label to pipeline docker ci

### DIFF
--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Build common live base image
     permissions:
       pull-requests: read
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, amd64]
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1
@@ -77,7 +77,7 @@ jobs:
   build-pipeline-images:
     name: Build pipeline images
     needs: build-common-base
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, amd64]
     permissions:
       pull-requests: read
     strategy:


### PR DESCRIPTION
This pull request adds the amd64 runner label to the pipeline docker ci to prevent any issues that can occur if the container is build on a arm64 machine.

