### PR TITLE
ci(runner): disable fail fast for batch docker ci

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   docker:

--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -81,9 +81,9 @@ jobs:
     permissions:
       pull-requests: read
     strategy:
+      fail-fast: false
       matrix:
         pipeline: [streamdiffusion, comfyui, liveportrait]
-      fail-fast: false
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-and-push-docker-images:
@@ -28,6 +28,7 @@ jobs:
       contents: read
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         dockerfile:
           - docker/Dockerfile.segment_anything_2


### PR DESCRIPTION
This pull request ensure that if one container build fails the other containers still are build.
