### PR TITLE
ci(runner): enable docker build cancel-in-progress on feature branches

### DIFF
--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
     paths:
       - "runner/**"
       - "!runner/.devcontainer/**"
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+  cancel-in-progress: ${{ !((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
 
 jobs:
   docker:

--- a/.github/workflows/ai-runner-docker.yaml
+++ b/.github/workflows/ai-runner-docker.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
 
 jobs:
   docker:

--- a/.github/workflows/ai-runner-live-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-live-pipelines-docker.yaml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ !((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
 
 jobs:
   build-common-base:

--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
 
 jobs:
   build-and-push-docker-images:

--- a/.github/workflows/ai-runner-pipelines-docker.yaml
+++ b/.github/workflows/ai-runner-pipelines-docker.yaml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+  cancel-in-progress: ${{ !((github.ref_type == 'branch' && github.ref_name == 'main') || github.ref_type == 'tag') }}
 
 jobs:
   build-and-push-docker-images:


### PR DESCRIPTION
This pull request enables the `cancel-in-progress` setting for feature branches, while keeping it disabled on the main branch. This ensures that all Docker containers on the main branch are built without interruption. For feature branches, new commits will cancel any in-progress workflows, speeding up development times by allowing engineers to quickly push new changes.
