### PR TITLE
Fix dl_checkpoints.sh: don use `-it` flag when running docker containers

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -103,7 +103,7 @@ function build_tensorrt_models() {
     # StreamDiffusion (compile a matrix of models and timesteps)
     MODELS="stabilityai/sd-turbo KBlueLeaf/kohaku-v2.1"
     TIMESTEPS="3 4" # This is basically the supported sizes for the t_index_list
-    docker run --rm -it -v ./models:/models --gpus all \
+    docker run --rm -v ./models:/models --gpus all \
         livepeer/ai-runner:live-app-streamdiffusion \
         bash -c "for model in $MODELS; do
                     for timestep in $TIMESTEPS; do
@@ -113,7 +113,7 @@ function build_tensorrt_models() {
                 done"
 
     # FasterLivePortrait
-    docker run --rm -it -v ./models:/models --gpus all \
+    docker run --rm -v ./models:/models --gpus all \
         livepeer/ai-runner:live-app-liveportrait \
         bash -c "cd /app/app/live/FasterLivePortrait && \
                     if [ ! -f '/models/FasterLivePortrait--checkpoints/liveportrait_onnx/stitching_lip.trt' ]; then
@@ -130,7 +130,7 @@ function build_tensorrt_models() {
                     fi"
 
     # ComfyUI (only DepthAnything for now)
-    docker run --rm -it -v ./models:/models --gpus all \
+    docker run --rm -v ./models:/models --gpus all \
         livepeer/ai-runner:live-app-comfyui \
         bash -c "cd /comfyui/models/Depth-Anything-Onnx && \
                     python /comfyui/custom_nodes/ComfyUI-Depth-Anything-Tensorrt/export_trt.py && \


### PR DESCRIPTION
I believe that `--interactive` and `--tty` (`-it`) was placed inside the non-interactive bash script by mistake.

It makes it problematic to run with ansible.