### PR TITLE
runner/docker: Fix streamdiffusion base image

### DIFF
--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir --upgrade pip==${PIP_VERSION} setuptools==69.5.1 
 RUN pip install --no-cache-dir \
     torch==2.1.0 \
     torchvision==0.16.0 \
-    xformers \
+    xformers===0.0.22.post7 \
     --index-url https://download.pytorch.org/whl/cu121
 
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -20,7 +20,6 @@ RUN pip install --no-cache-dir \
     --index-url https://download.pytorch.org/whl/cu121
 RUN pip install --no-cache-dir \
     huggingface-hub==0.23.2 \
-    diffusers==0.30.0 \
     protobuf==5.27.2 \
     nvidia-ml-py==12.560.30
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -18,10 +18,6 @@ RUN pip install --no-cache-dir \
     torchvision==0.16.0 \
     xformers \
     --index-url https://download.pytorch.org/whl/cu121
-RUN pip install --no-cache-dir \
-    huggingface-hub==0.23.2 \
-    protobuf==5.27.2 \
-    nvidia-ml-py==12.560.30
 
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
 RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -22,10 +22,10 @@ RUN pip install --no-cache-dir \
     huggingface-hub==0.23.2 \
     diffusers==0.30.0 \
     protobuf==5.27.2 \
-    nvidia-ml-py==12.560.30 
+    nvidia-ml-py==12.560.30
 
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
-RUN pip install git+https://github.com/pschroedl/StreamDiffusion.git@ab5c9c1#egg=streamdiffusion[tensorrt]
+RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
 
 # Install TensorRT extension
 RUN python -m streamdiffusion.tools.install-tensorrt

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -22,8 +22,9 @@ RUN pip install --no-cache-dir \
 # Install StreamDiffusion @ 765d71029b1404b94aee2865178d71c257c20318 (latest at time of writing)
 RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
 
-# Install TensorRT extension
-RUN python -m streamdiffusion.tools.install-tensorrt
+# Install TensorRT extension (requires huggingface-hub)
+RUN pip install --no-cache-dir huggingface-hub==0.23.2 && \
+    python -m streamdiffusion.tools.install-tensorrt
 
 WORKDIR /app
 

--- a/runner/docker/Dockerfile.live-base-streamdiffusion
+++ b/runner/docker/Dockerfile.live-base-streamdiffusion
@@ -23,7 +23,7 @@ RUN pip install --no-cache-dir \
 RUN pip install git+https://github.com/cumulo-autumn/StreamDiffusion.git@765d710#egg=streamdiffusion[tensorrt]
 
 # Install TensorRT extension (requires huggingface-hub)
-RUN pip install --no-cache-dir huggingface-hub==0.23.2 && \
+RUN pip install --no-cache-dir huggingface-hub==0.24.0 && \
     python -m streamdiffusion.tools.install-tensorrt
 
 WORKDIR /app


### PR DESCRIPTION
Mainly to revert back to the main StreamDiffusion repo installation which uses `diffusers===0.24.0`
0.30.0 breaks it

Also removed other extraneous dependencies being installed in the dockerfile though.