### PR TITLE
bump commit hash for streamdiffusion node, update dl_checkpoints.sh

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -87,12 +87,19 @@ function download_live_models() {
     huggingface-cli download warmshao/FasterLivePortrait --local-dir models/FasterLivePortrait--checkpoints
     huggingface-cli download yuvraj108c/Depth-Anything-Onnx --include depth_anything_vitl14.onnx --local-dir models/ComfyUI--models/Depth-Anything-Onnx
     download_sam2_checkpoints
+    download_stable_diffusion_checkpoints
 }
 
 function download_sam2_checkpoints() {
     huggingface-cli download facebook/sam2-hiera-tiny --local-dir models/sam2--checkpoints/facebook--sam2-hiera-tiny
     huggingface-cli download facebook/sam2-hiera-small --local-dir models/sam2--checkpoints/facebook--sam2-hiera-small
     huggingface-cli download facebook/sam2-hiera-large --local-dir models/sam2--checkpoints/facebook--sam2-hiera-large
+}
+
+function download_stable_diffusion_checkpoints() {
+    # ComfyUI-StableDiffusion expects a non-symlink .safetensors file - this should probably be changed to (also) accept HF cached models
+    wget -P models/checkpoints/ https://huggingface.co/KBlueLeaf/kohaku-v2.1/resolve/main/kohaku-v2.1.safetensors
+    wget -P models/checkpoints/ https://huggingface.co/stabilityai/sd-turbo/resolve/main/sd_turbo.safetensors
 }
 
 function build_tensorrt_models() {
@@ -190,6 +197,7 @@ done
 echo "Starting livepeer AI subnet model downloader..."
 echo "Creating 'models' directory in the current working directory..."
 mkdir -p models
+mkdir -p models/checkpoints
 mkdir -p models/StreamDiffusion--engines models/FasterLivePortrait--checkpoints models/ComfyUI--models models/sam2--checkpoints
 
 # Ensure 'huggingface-cli' is installed.

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -97,9 +97,8 @@ function download_sam2_checkpoints() {
 }
 
 function download_stable_diffusion_checkpoints() {
-    # ComfyUI-StableDiffusion expects a non-symlink .safetensors file - this should probably be changed to (also) accept HF cached models
-    wget -P models/checkpoints/ https://huggingface.co/KBlueLeaf/kohaku-v2.1/resolve/main/kohaku-v2.1.safetensors
-    wget -P models/checkpoints/ https://huggingface.co/stabilityai/sd-turbo/resolve/main/sd_turbo.safetensors
+    huggingface-cli download KBlueLeaf/kohaku-v2.1 --local-dir models/checkpoints --include "*.safetensors"
+    huggingface-cli download stabilityai/sd-turbo --local-dir models/checkpoints --include "*.safetensors"
 }
 
 function build_tensorrt_models() {

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -55,7 +55,7 @@ RUN cd /comfyui/custom_nodes && \
 RUN cd /comfyui/custom_nodes && \
     git clone https://github.com/pschroedl/ComfyUI-StreamDiffusion.git && \
     cd ComfyUI-StreamDiffusion && \
-    git checkout 98cb9a4f56659a81cbf1969c1b88624150c39ebf && \
+    git checkout 032cf631385454ea99772c86377c0437c34ab733 && \
     pip install -r requirements.txt
 
 # Upgrade TensorRT to 10.6.0


### PR DESCRIPTION
Update streamdiffusion node to include improvements in :
https://github.com/pschroedl/ComfyUI-StreamDiffusion/pull/5

Updates DL_checkpoints to pull .safetensor checkpoint files as expected by new loading mechanism.

This should probably be fixed upstream in the node to use proper HF caching. Attempts were made to symlink the existing huggingface-cli downloaded models but that approach is not straightforward and this is a workaround that should be revisited.