### PR TITLE
streamer: Improve timestamp logic on status reporting

### DIFF
--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -43,6 +43,19 @@ class PipelineStatus(BaseModel):
         self.last_params_hash = str(hash(str(sorted(params.items()))))
         return self
 
+    def model_dump(self, **kwargs):
+        data = super().model_dump(**kwargs)
+        # Convert all fields ending with _time to milliseconds
+        for field, value in data.items():
+            if field.endswith('_time'):
+                data[field] = _timestamp_to_ms(value)
+        return data
+
+
+def _timestamp_to_ms(v: float | None) -> int | None:
+    return int(v * 1000) if v is not None else None
+
+
 class PipelineStreamer:
     def __init__(self, protocol: StreamProtocol, pipeline: str, input_timeout: int, params: dict):
         self.protocol = protocol

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -188,6 +188,7 @@ class PipelineStreamer:
 
     async def _emit_monitoring_event(self, event: dict):
         """Protected method to emit monitoring event with lock"""
+        event["timestamp"] = _timestamp_to_ms(time.time())
         async with self.report_status_lock:
             try:
                 await self.protocol.emit_monitoring_event(event)


### PR DESCRIPTION
- change timestamps to int ms instead of float sec
- add a `timestamp` to every event as well (incl status, from the time we send)