### PR TITLE
update comfui_stablediffusion, add checkpoints and lora

### DIFF
--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -95,6 +95,7 @@ function download_live_models() {
     huggingface-cli download yuvraj108c/Depth-Anything-Onnx --include depth_anything_vitl14.onnx --local-dir models/ComfyUI--models/Depth-Anything-Onnx
     download_sam2_checkpoints
     download_stable_diffusion_checkpoints
+    download_stable_diffusion_loras
 }
 
 function download_sam2_checkpoints() {
@@ -106,6 +107,19 @@ function download_sam2_checkpoints() {
 function download_stable_diffusion_checkpoints() {
     huggingface-cli download KBlueLeaf/kohaku-v2.1 --local-dir models/models/ComfyUI--models/checkpoints --include "*.safetensors"
     huggingface-cli download stabilityai/sd-turbo --local-dir models/models/ComfyUI--models/checkpoints --include "*.safetensors"
+
+    # ComfyUI_StreamDIffusion is loading single file safetensors from /models/checkpoints
+    wget -P models/checkpoints/ https://huggingface.co/KBlueLeaf/kohaku-v2.1/resolve/main/kohaku-v2.1.safetensors
+    wget -P models/checkpoints/ https://huggingface.co/stabilityai/sd-turbo/resolve/main/sd_turbo.safetensors
+    # chenxxiao/3dCartoonVision_v10
+    wget -P models/checkpoints https://huggingface.co/chenxxiao/3dCartoonVision_v10/resolve/main/3dCartoonVision_v10.safetensors?download=true --content-disposition
+}
+
+function download_stable_diffusion_loras() {
+# ral-dissolve-sd15 LoRA
+    wget -P models/loras https://civitai.com/api/download/models/314246?type=Model&format=SafeTensor --content-disposition
+}
+
 }
 
 function build_tensorrt_models() {

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -107,12 +107,12 @@ function download_sam2_checkpoints() {
 
 function download_stream_diffusion_checkpoints() {
     # ComfyUI_StreamDiffusion is loading single file safetensors from /models/checkpoints
-    huggingface-cli download pschroedl/comfystream_checkpoints --local-dir models/checkpoints --include "*.safetensors"
+    huggingface-cli download pschroedl/comfystream_checkpoints --local-dir models/ComfyUI--models/checkpoints --include "*.safetensors"
 }
 
 function download_stream_diffusion_loras() {
     # ral-dissolve-sd15 LoRA
-    huggingface-cli download pschroedl/comfystream_loras --local-dir models/loras --include "*.safetensors"
+    huggingface-cli download pschroedl/comfystream_loras --local-dir models/ComfyUI--models/loras --include "*.safetensors"
 }
 
 function build_tensorrt_models() {

--- a/runner/dl_checkpoints.sh
+++ b/runner/dl_checkpoints.sh
@@ -109,15 +109,12 @@ function download_stable_diffusion_checkpoints() {
     huggingface-cli download stabilityai/sd-turbo --local-dir models/ComfyUI--models/checkpoints --include "*.safetensors"
 
     # ComfyUI_StreamDIffusion is loading single file safetensors from /models/checkpoints
-    wget -P models/checkpoints/ https://huggingface.co/KBlueLeaf/kohaku-v2.1/resolve/main/kohaku-v2.1.safetensors
-    wget -P models/checkpoints/ https://huggingface.co/stabilityai/sd-turbo/resolve/main/sd_turbo.safetensors
-    # chenxxiao/3dCartoonVision_v10
-    wget -P models/checkpoints https://huggingface.co/chenxxiao/3dCartoonVision_v10/resolve/main/3dCartoonVision_v10.safetensors?download=true --content-disposition
+    huggingface-cli download pschroedl/comfystream_checkpoints --local-dir models/checkpoints --include "*.safetensors"
 }
 
 function download_stable_diffusion_loras() {
     # ral-dissolve-sd15 LoRA
-    wget -P models/loras https://civitai.com/api/download/models/314246?type=Model&format=SafeTensor --content-disposition
+    huggingface-cli download pschroedl/comfystream_loras --local-dir models/loras --include "*.safetensors"
 }
 
 function build_tensorrt_models() {

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -61,7 +61,7 @@ RUN cd /comfyui/custom_nodes && \
 RUN cd /comfyui/custom_nodes && \
     git clone https://github.com/pschroedl/ComfyUI-StreamDiffusion.git && \
     cd ComfyUI-StreamDiffusion && \
-    git checkout 032cf631385454ea99772c86377c0437c34ab733 && \
+    git checkout 32f88480736e30d6c1d97b9adfe483dd265769b3 && \
     pip install -r requirements.txt
 
 # Upgrade TensorRT to 10.6.0

--- a/runner/docker/Dockerfile.live-base-comfyui
+++ b/runner/docker/Dockerfile.live-base-comfyui
@@ -61,7 +61,7 @@ RUN cd /comfyui/custom_nodes && \
 RUN cd /comfyui/custom_nodes && \
     git clone https://github.com/pschroedl/ComfyUI-StreamDiffusion.git && \
     cd ComfyUI-StreamDiffusion && \
-    git checkout 32f88480736e30d6c1d97b9adfe483dd265769b3 && \
+    git checkout f93b98aa9f20ab46c23d149ad208d497cd496579 && \
     pip install -r requirements.txt
 
 # Upgrade TensorRT to 10.6.0


### PR DESCRIPTION
Performance updates to ComfyUI_StableDiffusion from:
https://github.com/pschroedl/ComfyUI-StreamDiffusion/pull/6
Example Workflow Updates:
https://github.com/pschroedl/ComfyUI-StreamDiffusion/pull/7

Node now loads safetensor files ( full huggingface checkpoint loading is broken ), this PR adds checkpoints for:
sd_turbo.safetensors, kohaku_v2.1.safetensors and
https://huggingface.co/chenxxiao/3dCartoonVision_v10

and lora : ral-dissolve1.5
https://civitai.com/models/245889?modelVersionId=314246
