### PR TITLE
trickle: Add reconnects in subscriber.

### DIFF
--- a/runner/app/live/trickle/trickle_subscriber.py
+++ b/runner/app/live/trickle/trickle_subscriber.py
@@ -4,13 +4,14 @@ import logging
 import sys
 
 class TrickleSubscriber:
-    def __init__(self, url: str):
+    def __init__(self, url: str, max_retries=5):
         self.base_url = url
         self.idx = -1  # Start with -1 for 'latest' index
         self.pending_get: aiohttp.ClientResponse | None = None  # Pre-initialized GET request
         self.lock = asyncio.Lock()  # Lock to manage concurrent access
         self.session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False))
         self.errored = False
+        self.max_retries = max_retries
 
     async def __aenter__(self):
         """Enter context manager."""
@@ -21,32 +22,57 @@ class TrickleSubscriber:
         await self.close()
 
     async def preconnect(self):
-        """Preconnect to the server by making a GET request to fetch the next segment."""
+        """
+            Preconnect to the server by making a GET request to fetch the next segment.
+            For any non-200 responses, retries up to max_retries unless a 404 is encountered
+        """
         url = f"{self.base_url}/{self.idx}"
-        logging.info(f"Trickle sub Preconnecting to URL: {url}")
-        try:
+        for attempt in range(0, self.max_retries):
+            logging.info(f"Trickle sub Preconnecting attempt: {attempt} URL: {url}")
+            try:
 
-            resp = await self.session.get(url, headers={'Connection':'close'})
-            if resp.status != 200:
+                resp = await self.session.get(url, headers={'Connection':'close'})
+
+                if resp.status == 200:
+                    # Return the response for later processing
+                    return resp
+
+                if resp.status == 404:
+                    logging.info(f"Trickle sub got 404, terminating {url}")
+                    resp.release()
+                    self.errored = True
+                    return None
+
+                if resp.status == 470:
+                    # channel exists but no data at this index, so reset
+                    idx = resp.headers.get('Lp-Trickle-Latest') or '-1'
+                    url = f"{self.base_url}/{idx}"
+                    logging.info(f"Trickle sub resetting index to leading edge {url}")
+                    resp.release()
+                    # continue immediately
+                    continue
+
                 body = await resp.text()
                 resp.release()
-                logging.error(f"Trickle sub Failed GET segment, status code: {resp.status}, msg: {body}")
-                self.errored = True
-                return None
+                logging.error(f"Trickle sub Failed GET {url} status code: {resp.status}, msg: {body}")
 
-            # Return the response for later processing
-            return resp
-        except aiohttp.ClientError as e:
-            logging.error(f"Trickle sub Failed to complete GET for next segment: {e}")
-            self.errored = True
-            return None
+            except aiohttp.ClientError as e:
+                logging.error(f"Trickle sub Failed to complete GET {url} error: {e}")
+
+            if attempt < self.max_retries - 1:
+                await asyncio.sleep(0.5)
+
+        # max retries hit, so bail out
+        logging.error(f"Trickle sub hit max retries, exiting {url}")
+        self.errored = True
+        return None
 
     async def next(self):
         """Retrieve data from the current segment and set up the next segment concurrently."""
         async with self.lock:
 
             if self.errored:
-                logging.info("Trickle subscription closed or errored")
+                logging.info("Trickle subscription closed or errored for {url}")
                 return None
 
             # If we don't have a pending GET request, preconnect
@@ -57,6 +83,10 @@ class TrickleSubscriber:
             # Extract the current connection to use for reading
             resp = self.pending_get
             self.pending_get = None
+
+            # Preconnect has failed, notify caller
+            if resp is None:
+                return None
 
             # Extract and set the next index from the response headers
             segment = Segment(resp)


### PR DESCRIPTION
Defaults to 5 retries with a 500ms sleep in between.

Exits on a 404 (trickle channel does not exist)

Also detects the case where the trickle channel exists but the segment in the sequence does not (via special status  code 470) and jumps to the leading edge.

See server implementation adding status code 470 support: https://github.com/livepeer/go-livepeer/pull/3327