### PR TITLE
live/streamer: Fix streamer shutdown logic

### DIFF
--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--input-timeout",
         type=int,
-        default=50,
+        default=60,
         help="Timeout in seconds to wait after input frames stop before shutting down. Set to 0 to disable."
     )
     parser.add_argument(

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -51,7 +51,7 @@ async def main(*, http_port: int, stream_protocol: str, subscribe_url: str, publ
         logging.error(f"Stack trace:\n{traceback.format_exc()}")
         raise e
     finally:
-        await streamer.stop()
+        await streamer.stop(timeout=5)
         await api.cleanup()
 
 

--- a/runner/app/live/infer.py
+++ b/runner/app/live/infer.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--input-timeout",
         type=int,
-        default=60,
+        default=50,
         help="Timeout in seconds to wait after input frames stop before shutting down. Set to 0 to disable."
     )
     parser.add_argument(

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -34,7 +34,10 @@ class PipelineProcess:
         self.done = self.ctx.Event()
         self.process = self.ctx.Process(target=self.process_loop, args=())
 
-    def stop(self):
+    async def stop(self):
+        await asyncio.to_thread(self._stop_sync)
+
+    def _stop_sync(self):
         self.done.set()
         if not self.process.is_alive():
             logging.info("Process already not alive")

--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -19,6 +19,7 @@ class PipelineProcess:
         if params:
             instance.update_params(params)
         instance.process.start()
+        instance.start_time = time.time()
         return instance
 
     def __init__(self, pipeline_name: str):
@@ -33,6 +34,7 @@ class PipelineProcess:
 
         self.done = self.ctx.Event()
         self.process = self.ctx.Process(target=self.process_loop, args=())
+        self.start_time = 0
 
     async def stop(self):
         await asyncio.to_thread(self._stop_sync)

--- a/runner/app/live/streamer/protocol/protocol.py
+++ b/runner/app/live/streamer/protocol/protocol.py
@@ -32,7 +32,7 @@ class StreamProtocol(ABC):
         pass
 
     @abstractmethod
-    async def control_loop(self) -> AsyncGenerator[dict, None]:
+    async def control_loop(self, done: asyncio.Event) -> AsyncGenerator[dict, None]:
         """Generator that yields control messages for updating pipeline parameters"""
         if False:
             yield {}  # dummy yield for proper typing

--- a/runner/app/live/streamer/protocol/protocol.py
+++ b/runner/app/live/streamer/protocol/protocol.py
@@ -1,6 +1,6 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator
-from multiprocessing.synchronize import Event
 from PIL import Image
 
 class StreamProtocol(ABC):
@@ -15,7 +15,7 @@ class StreamProtocol(ABC):
         pass
 
     @abstractmethod
-    async def ingress_loop(self, done: Event) -> AsyncGenerator[Image.Image, None]:
+    async def ingress_loop(self, done: asyncio.Event) -> AsyncGenerator[Image.Image, None]:
         """Generator that yields the ingress frames"""
         if False:
             yield Image.new('RGB', (1, 1))  # dummy yield for type checking

--- a/runner/app/live/streamer/protocol/trickle.py
+++ b/runner/app/live/streamer/protocol/trickle.py
@@ -97,7 +97,7 @@ class TrickleProtocol(StreamProtocol):
         except Exception as e:
             logging.error(f"Error reporting status: {e}")
 
-    async def control_loop(self) -> AsyncGenerator[dict, None]:
+    async def control_loop(self, done: asyncio.Event) -> AsyncGenerator[dict, None]:
         if not self.control_subscriber:
             logging.warning("No control-url provided, inference won't get updates from the control trickle subscription")
             return
@@ -105,7 +105,7 @@ class TrickleProtocol(StreamProtocol):
         logging.info("Starting Control subscriber at %s", self.control_url)
         keepalive_message = {"keep": "alive"}
 
-        while True:
+        while not done.is_set():
             try:
                 segment = await self.control_subscriber.next()
                 if not segment or segment.eos():

--- a/runner/app/live/streamer/protocol/trickle.py
+++ b/runner/app/live/streamer/protocol/trickle.py
@@ -2,10 +2,9 @@ import asyncio
 import logging
 import queue
 import json
-from typing import AsyncGenerator, Optional, Callable
+from typing import AsyncGenerator, Optional
 
 from PIL import Image
-from multiprocessing.synchronize import Event
 
 from trickle import media, TricklePublisher, TrickleSubscriber
 
@@ -63,7 +62,7 @@ class TrickleProtocol(StreamProtocol):
         self.subscribe_task = None
         self.publish_task = None
 
-    async def ingress_loop(self, done: Event) -> AsyncGenerator[Image.Image, None]:
+    async def ingress_loop(self, done: asyncio.Event) -> AsyncGenerator[Image.Image, None]:
         def dequeue_jpeg():
             jpeg_bytes = self.subscribe_queue.get()
             if not jpeg_bytes:

--- a/runner/app/live/streamer/protocol/zeromq.py
+++ b/runner/app/live/streamer/protocol/zeromq.py
@@ -1,9 +1,7 @@
-import io
-
+import asyncio
 import zmq.asyncio
 from PIL import Image
-from multiprocessing.synchronize import Event
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator
 
 from .protocol import StreamProtocol
 from .jpeg import to_jpeg_bytes, from_jpeg_bytes
@@ -29,7 +27,7 @@ class ZeroMQProtocol(StreamProtocol):
         self.output_socket.close()
         self.context.term()
 
-    async def ingress_loop(self, done: Event) -> AsyncGenerator[Image.Image, None]:
+    async def ingress_loop(self, done: asyncio.Event) -> AsyncGenerator[Image.Image, None]:
         while not done.is_set():
             frame_bytes = await self.input_socket.recv()
             yield from_jpeg_bytes(frame_bytes)

--- a/runner/app/live/streamer/protocol/zeromq.py
+++ b/runner/app/live/streamer/protocol/zeromq.py
@@ -40,7 +40,7 @@ class ZeroMQProtocol(StreamProtocol):
     async def emit_monitoring_event(self, event: dict):
         pass  # No-op for ZeroMQ
 
-    async def control_loop(self) -> AsyncGenerator[dict, None]:
+    async def control_loop(self, done: asyncio.Event) -> AsyncGenerator[dict, None]:
         if False:
             yield {}  # Empty generator, dummy yield for proper typing
-        pass # ZeroMQ protocol does not support control messages
+        await done.wait() # ZeroMQ protocol does not support control messages so just wait for the stop event

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -77,8 +77,7 @@ class PipelineStreamer:
         for task in pending:
             task.cancel()
 
-        stop_tasks = [asyncio.create_task(t) for t in [self.protocol.stop(), self.process.stop()]]
-        await asyncio.wait(stop_tasks, return_when=asyncio.ALL_COMPLETED)
+        await asyncio.gather(self.protocol.stop(), self.process.stop(), return_exceptions=True)
 
     async def wait(self):
         if not self.process:

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -162,13 +162,14 @@ class PipelineStreamer:
 
     def _current_state(self) -> str:
         current_time = time.time()
-        last_input_time = self.status.input_status.last_input_time or 0
+        input = self.status.input_status
+        last_input_time = input.last_input_time or 0
         if current_time - last_input_time > 60:
             if self.stop_event.is_set() and current_time - last_input_time < 90:
                 # give ourselves a 30s grace period to shutdown
                 return PipelineState.DEGRADED_INPUT
             return PipelineState.OFFLINE
-        elif current_time - input.last_input_time > 2 or input.fps < 15:
+        elif current_time - last_input_time > 2 or input.fps < 15:
             return PipelineState.DEGRADED_INPUT
 
         inference = self.status.inference_status

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -217,9 +217,9 @@ class PipelineStreamer:
 
             start_time = self.process.start_time
             current_time = time.time()
-            last_input_time = self.status.input_status.last_input_time or start_time
-            last_output_time = self.status.inference_status.last_output_time or start_time
-            last_params_update_time = self.status.inference_status.last_params_update_time or start_time
+            last_input_time = max(self.status.input_status.last_input_time or 0, start_time)
+            last_output_time = max(self.status.inference_status.last_output_time or 0, start_time)
+            last_params_update_time = max(self.status.inference_status.last_params_update_time or 0, start_time)
 
             time_since_last_input = current_time - last_input_time
             time_since_last_output = current_time - last_output_time

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -198,7 +198,6 @@ class PipelineStreamer:
                 logging.error(f"Failed to emit monitoring event: {e}")
 
     async def monitor_loop(self):
-        start_time = time.time()
         while not self.stop_event.is_set():
             await asyncio.sleep(1)
             if not self.process or self.process.done.is_set():
@@ -216,6 +215,7 @@ class PipelineStreamer:
                     "time": error_time
                 })
 
+            start_time = self.process.start_time
             current_time = time.time()
             last_input_time = self.status.input_status.last_input_time or start_time
             last_output_time = self.status.inference_status.last_output_time or start_time

--- a/runner/app/live/streamer/streamer.py
+++ b/runner/app/live/streamer/streamer.py
@@ -328,16 +328,12 @@ class PipelineStreamer:
 
     async def run_control_loop(self):
         """Consumes control messages from the protocol and updates parameters"""
-        try:
-            async for params in self.protocol.control_loop():
-                try:
-                    await self.update_params(params)
-                except Exception as e:
-                    logging.error(f"Error updating model with control message: {e}")
-            logging.info("Control loop ended")
-            # control loop it not required to be running, so we keep the streamer running
-        except Exception as e:
-            logging.error(f"Error in control loop", exc_info=True)
+        async for params in self.protocol.control_loop(self.stop_event):
+            try:
+                await self.update_params(params)
+            except Exception as e:
+                logging.error(f"Error updating model with control message: {e}")
+        logging.info("Control loop ended")
 
 
 def run_in_background(task_name: str, coro: Awaitable):


### PR DESCRIPTION
After working on #371 I realized how messy the lifecycle management of the streamer was.
This is to simplify and improve that a bunch.

## Issues
Previously, we started a bunch of loose background tasks and had no central way of controlling them.
There were mainly 2 issues:
- Some of the tasks were started/restarted together with the inference process. This caused an additional complexity in the tasks themselves and in the task management logic.
- The stop() function was called from several different places, including from the tasks themselves that were being restarted. The restart function also killed some of the tasks that called it (cause they were recreated with the process).

## Fixes
So this improved this 2 issues in 2 steps:
- First made sure that all the asyncio tasks are started with the streamer itself. The main change here was changing the looping logic so we check the main "stop_event" instead of the process.done() event.
- Second, created a new "supervisor task" to rule them all. Instead of calling stop from multiple places, only the supervisor task actually stops everything now anytime one of the tasks end or the stop_event is set.

This will also make sure that we don't keep the streamer running when any of the tasks fail. This happened for the monitor loop on a recent version and no one ever realized, cause it only got logged but didn't crash the whole thing.