### PR TITLE
feat: enable fully external configuration

### DIFF
--- a/cmd/examples/image-to-image/main.go
+++ b/cmd/examples/image-to-image/main.go
@@ -33,7 +33,9 @@ func main() {
 
 	modelID := "stabilityai/sd-turbo"
 
-	w, err := worker.NewWorker(containerImageID, gpus, modelsDir)
+	external := false
+
+	w, err := worker.NewWorker(containerImageID, gpus, modelsDir, external)
 	if err != nil {
 		slog.Error("Error creating worker", slog.String("error", err.Error()))
 		return

--- a/cmd/examples/image-to-video/main.go
+++ b/cmd/examples/image-to-video/main.go
@@ -33,7 +33,9 @@ func main() {
 
 	modelID := "stabilityai/stable-video-diffusion-img2vid-xt"
 
-	w, err := worker.NewWorker(containerImageID, gpus, modelsDir)
+	external := false
+
+	w, err := worker.NewWorker(containerImageID, gpus, modelsDir, external)
 	if err != nil {
 		slog.Error("Error creating worker", slog.String("error", err.Error()))
 		return

--- a/cmd/examples/text-to-image/main.go
+++ b/cmd/examples/text-to-image/main.go
@@ -32,7 +32,9 @@ func main() {
 
 	modelID := "stabilityai/sd-turbo"
 
-	w, err := worker.NewWorker(containerImageID, gpus, modelsDir)
+	external := false
+
+	w, err := worker.NewWorker(containerImageID, gpus, modelsDir, external)
 	if err != nil {
 		slog.Error("Error creating worker", slog.String("error", err.Error()))
 		return


### PR DESCRIPTION
This PR allows the worker to be fully configured to use external containers only, in which case the worker no longer needs active container management.

This is primarily useful when using a fully containerised setup using e.g. docker compose, where the `ai-runner` containers for various pipelines/models are isolated containers. 

In such case, the need for access to the Docker daemon from the `ai-worker`, would prevent this setup from running because by default the **host's docker daemon isn't available for other containers**.

```
E1227 10:53:39.195246       1 starter.go:1216] Error starting AI worker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

While for a hybrid setup (seems uncommon), the docker socket still has to be passed as a volume or docker has to be ran as a root, having the availability for a fully containerized setup would be highly beneficial.