### PR TITLE
process: Make sure params don't accumulate in queue

### DIFF
--- a/runner/app/live/streamer/process.py
+++ b/runner/app/live/streamer/process.py
@@ -158,7 +158,7 @@ class PipelineProcess:
     async def _initialize_pipeline(self):
         try:
             params = await self._get_latest_params(timeout=0.005)
-            if params:
+            if params is not None:
                 logging.info(f"PipelineProcess: Got params from param_update_queue {params}")
             else:
                 logging.info("PipelineProcess: No params found in param_update_queue, loading with default params")
@@ -239,7 +239,7 @@ class PipelineProcess:
         while not self.is_done():
             try:
                 params = await self._get_latest_params(timeout=0.1)
-                if not params:
+                if params is None:
                     continue
 
                 params_hash = hashlib.md5(json.dumps(params, sort_keys=True).encode()).hexdigest()


### PR DESCRIPTION
This is to add support to a high frequency stream of updates which might start
happening with the TD plugin being developed.

The idea is to make sure we always update to the latest provided params, instead
of going through each of the provided params step by step. So if the param updates
are not being processed fast enough, we should just skip to the latest instead of
letting them accumulate on the queue.

Also added some timing metric to have some idea how much these are taking.