### PR TITLE
streamdiffusion: Make sure we don't clear applied controlnets

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion.py
+++ b/runner/app/live/pipelines/streamdiffusion.py
@@ -282,9 +282,10 @@ class StreamDiffusion(Pipeline):
                 old_scale = applied_controlnets[i].conditioning_scale
                 if patched.conditioning_scale != old_scale:
                     self.pipe.update_controlnet_scale(i, patched.conditioning_scale)
+            # Only update the applied_controlnets if we actually patched something
+            self.applied_controlnets = patched_controlnets
 
         self.params = new_params
-        self.applied_controlnets = patched_controlnets
         self.first_frame = True
         return True
 


### PR DESCRIPTION
When we did a non-update to controlnets we were clearing the applied_controlnets field because patched_controlnets was never initialized: we don't process params that have the same value as the original.