### PR TITLE
Fix docker build bad substitution error

### DIFF
--- a/.github/workflows/streamdiffusion-docker.yaml
+++ b/.github/workflows/streamdiffusion-docker.yaml
@@ -126,7 +126,7 @@ jobs:
         run: |
           set -ex
 
-          FILE_SUFFIX="${env.DOCKER_SUFFIX//-/_}"
+          FILE_SUFFIX="$(printf '%s' "$DOCKER_SUFFIX" | tr '-' '_')"
           JSON_FILE="runner/app/live/pipelines/streamdiffusion${FILE_SUFFIX}_default_params.json"
           if [ ! -f "$JSON_FILE" ]; then
             echo "Params file missing: $JSON_FILE" >&2


### PR DESCRIPTION
Fix "bad substitution" error in `streamdiffusion-docker.yaml` by using POSIX-safe `tr` for `FILE_SUFFIX` assignment.

The previous `FILE_SUFFIX="${env.DOCKER_SUFFIX//-/_}"` used bash-specific parameter expansion (`//`) which caused a "bad substitution" error when executed in a `sh` shell. This change replaces it with `FILE_SUFFIX="$(printf '%s' "$DOCKER_SUFFIX" | tr '-' '_')"` which is POSIX-compliant.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaddc728-0825-4870-a946-782aaa18c1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eaddc728-0825-4870-a946-782aaa18c1bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

