### PR TITLE
streamdiffusion: Revert useless changes to lcm_lora_id

### DIFF
--- a/runner/app/live/pipelines/streamdiffusion_sdxl_default_params.json
+++ b/runner/app/live/pipelines/streamdiffusion_sdxl_default_params.json
@@ -12,7 +12,7 @@
   "height": 512,
   "lora_dict": null,
   "use_lcm_lora": true,
-  "lcm_lora_id": "latent-consistency/lcm-lora-sdxl",
+  "lcm_lora_id": "latent-consistency/lcm-lora-sdv1-5",
   "acceleration": "tensorrt",
   "use_denoising_batch": true,
   "do_add_noise": true,

--- a/runner/app/live/pipelines/streamdiffusion_sdxl_faceid_default_params.json
+++ b/runner/app/live/pipelines/streamdiffusion_sdxl_faceid_default_params.json
@@ -14,7 +14,7 @@
   "height": 512,
   "lora_dict": null,
   "use_lcm_lora": true,
-  "lcm_lora_id": "latent-consistency/lcm-lora-sdxl",
+  "lcm_lora_id": "latent-consistency/lcm-lora-sdv1-5",
   "acceleration": "tensorrt",
   "use_denoising_batch": true,
   "do_add_noise": true,


### PR DESCRIPTION
it's not even used for SDXL, fn GPT smart ass