### PR TITLE
routes: Fix version and hardware metadata routes

### DIFF
--- a/docs/custom-pipeline.md
+++ b/docs/custom-pipeline.md
@@ -421,6 +421,8 @@ Batch pipelines extend a different base class:
 from runner.pipelines.base import Pipeline
 
 class MyBatchPipeline(Pipeline):
+    name: str = "my-batch-pipeline"
+
     def __init__(self, model_id: str, model_dir: str = "/models"):
         self.model_id = model_id
         self.model_dir = model_dir

--- a/runner/gateway.openapi.yaml
+++ b/runner/gateway.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: Livepeer AI Runner
   description: An application to run AI pipelines
-  version: 0.13.11
+  version: 0.14.0
 servers:
 - url: https://dream-gateway.livepeer.cloud
   description: Livepeer Cloud Community Gateway

--- a/runner/openapi.yaml
+++ b/runner/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: Livepeer AI Runner
   description: An application to run AI pipelines
-  version: 0.13.11
+  version: 0.14.0
 servers:
 - url: https://dream-gateway.livepeer.cloud
   description: Livepeer Cloud Community Gateway

--- a/runner/src/runner/pipelines/audio_to_text.py
+++ b/runner/src/runner/pipelines/audio_to_text.py
@@ -59,6 +59,8 @@ INCOMPATIBLE_EXTENSIONS = ["mp4", "m4a", "ac3"]
 
 
 class AudioToTextPipeline(Pipeline):
+    name: str = "audio-to-text"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {}

--- a/runner/src/runner/pipelines/base.py
+++ b/runner/src/runner/pipelines/base.py
@@ -15,6 +15,12 @@ class Version(BaseModel):
     version: str = Field(..., description="The version of the Runner")
 
 class Pipeline(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """The pipeline name used for routing (e.g. 'text-to-image', 'live-video-to-video', etc)."""
+        ...
+
     @abstractmethod
     def __init__(self, model_id: str, model_dir: str):
         self.model_id: str # declare the field here so the type hint is available when using this abstract class

--- a/runner/src/runner/pipelines/frame_interpolation.py
+++ b/runner/src/runner/pipelines/frame_interpolation.py
@@ -2,4 +2,5 @@ from runner.pipelines.base import Pipeline
 
 
 class FrameInterpolationPipeline(Pipeline):
-    pass
+    name: str = "frame-interpolation"
+    # TODO: Not implemented

--- a/runner/src/runner/pipelines/image_to_image.py
+++ b/runner/src/runner/pipelines/image_to_image.py
@@ -46,6 +46,8 @@ class ModelName(Enum):
 
 
 class ImageToImagePipeline(Pipeline):
+    name: str = "image-to-image"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {"cache_dir": get_model_dir()}

--- a/runner/src/runner/pipelines/image_to_text.py
+++ b/runner/src/runner/pipelines/image_to_text.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class ImageToTextPipeline(Pipeline):
+    name: str = "image-to-text"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {}

--- a/runner/src/runner/pipelines/image_to_video.py
+++ b/runner/src/runner/pipelines/image_to_video.py
@@ -21,6 +21,8 @@ SFAST_WARMUP_ITERATIONS = 2  # Model warm-up iterations when SFAST is enabled.
 
 
 class ImageToVideoPipeline(Pipeline):
+    name: str = "image-to-video"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {"cache_dir": get_model_dir()}

--- a/runner/src/runner/pipelines/live_video_to_video.py
+++ b/runner/src/runner/pipelines/live_video_to_video.py
@@ -19,6 +19,8 @@ from runner.live.pipelines import PipelineSpec
 proc_status_important_fields = ["State", "VmRSS", "VmSize", "Threads", "voluntary_ctxt_switches", "nonvoluntary_ctxt_switches", "CoreDumping"]
 
 class LiveVideoToVideoPipeline(Pipeline):
+    name: str = "live-video-to-video"
+
     def __init__(self, pipeline_spec: PipelineSpec):
         self.version = os.getenv("VERSION", "undefined")
         self.model_id = pipeline_spec.name # we set the parent class model_id to the pipeline name for compatibility

--- a/runner/src/runner/pipelines/llm.py
+++ b/runner/src/runner/pipelines/llm.py
@@ -40,6 +40,8 @@ class GenerationConfig:
 
 
 class LLMPipeline(Pipeline):
+    name: str = "llm"
+
     def __init__(
         self,
         model_id: str,

--- a/runner/src/runner/pipelines/segment_anything_2.py
+++ b/runner/src/runner/pipelines/segment_anything_2.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class SegmentAnything2Pipeline(Pipeline):
+    name: str = "segment-anything-2"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {"cache_dir": get_model_dir()}

--- a/runner/src/runner/pipelines/text_to_image.py
+++ b/runner/src/runner/pipelines/text_to_image.py
@@ -48,6 +48,8 @@ class ModelName(Enum):
 
 
 class TextToImagePipeline(Pipeline):
+    name: str = "text-to-image"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {"cache_dir": get_model_dir()}

--- a/runner/src/runner/pipelines/text_to_speech.py
+++ b/runner/src/runner/pipelines/text_to_speech.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class TextToSpeechPipeline(Pipeline):
+    name: str = "text-to-speech"
+
     def __init__(self, model_id: str):
         self.device = get_torch_device()
         self.model_id = model_id

--- a/runner/src/runner/pipelines/upscale.py
+++ b/runner/src/runner/pipelines/upscale.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 class UpscalePipeline(Pipeline):
+    name: str = "upscale"
+
     def __init__(self, model_id: str):
         self.model_id = model_id
         kwargs = {"cache_dir": get_model_dir()}

--- a/runner/src/runner/routes/hardware.py
+++ b/runner/src/runner/routes/hardware.py
@@ -39,10 +39,11 @@ class HardwareStats(BaseModel):
     include_in_schema=False,
 )
 async def hardware_info(request: Request):
+    pipeline = request.app.pipeline
     gpu_info = await asyncio.to_thread(request.app.hardware_info_service.get_gpu_compute_info)
     return HardwareInformation(
-        pipeline=os.environ["PIPELINE"],
-        model_id=os.environ["MODEL_ID"],
+        pipeline=os.environ.get("PIPELINE", pipeline.name),
+        model_id=os.environ.get("MODEL_ID", pipeline.model_id),
         gpu_info=gpu_info,
     )
 
@@ -58,9 +59,10 @@ async def hardware_info(request: Request):
     include_in_schema=False,
 )
 async def hardware_stats(request: Request):
+    pipeline = request.app.pipeline
     gpu_stats = await asyncio.to_thread(request.app.hardware_info_service.get_gpu_utilization_stats)
     return HardwareStats(
-        pipeline=os.environ["PIPELINE"],
-        model_id=os.environ["MODEL_ID"],
+        pipeline=os.environ.get("PIPELINE", pipeline.name),
+        model_id=os.environ.get("MODEL_ID", pipeline.model_id),
         gpu_stats=gpu_stats,
     )

--- a/runner/src/runner/routes/version.py
+++ b/runner/src/runner/routes/version.py
@@ -1,15 +1,16 @@
 import os
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from runner.pipelines.base import Version
 
 router = APIRouter()
 
 @router.get("/version", operation_id="version", response_model=Version)
 @router.get("/version/", response_model=Version, include_in_schema=False)
-def version() -> Version:
+def version(request: Request) -> Version:
+    pipeline = request.app.pipeline
     return Version(
-        pipeline=os.environ["PIPELINE"],
-        model_id=os.environ["MODEL_ID"],
-        version=os.environ["VERSION"],
+        pipeline=os.environ.get("PIPELINE", pipeline.name),
+        model_id=os.environ.get("MODEL_ID", pipeline.model_id),
+        version=os.environ.get("VERSION", "undefined"),
     )


### PR DESCRIPTION
When running a custom pipeline, one still needed to set the `PIPELINE` and `MODEL_ID`
env vars which is super annoying, especially when running locally with `uv run`.

This avoids that by returning the `PIPELINE` and `MODEL_ID` configurations from the
actual running pipeline, in case the envs are not set. We should consider even deprecating
the envs altogether, but I'm trying to make smaller changes since I won't be around to test
this further.